### PR TITLE
Implement RemoteMFE.doUpdateControlPlaneState() with daemon WS mutation

### DIFF
--- a/src/runtime/base-mfe.ts
+++ b/src/runtime/base-mfe.ts
@@ -11,9 +11,11 @@
 
 import type { DSLManifest, LifecycleHook, LifecycleHookEntry } from '../dsl/schema';
 import { Context, UserContext, TelemetryEvent } from './context';
+import type { DaemonWebSocketClient } from './graphql-ws-client';
 
 // Re-export for convenience
 export type { Context, UserContext, TelemetryEvent };
+export type { DaemonWebSocketClient };
 
 // =============================================================================
 // Dependency Injection Interfaces
@@ -55,6 +57,8 @@ export interface BaseMFEDependencies {
   manifestParser?: ManifestParser;
   lifecycleExecutor?: LifecycleExecutor;
   errorHandler?: ErrorHandler;
+  /** graphql-transport-ws connection to the daemon, shared with the Renderer's messages subscription */
+  wsClient?: DaemonWebSocketClient;
 }
 
 // =============================================================================
@@ -125,6 +129,8 @@ export interface ControlPlaneStateResult {
   acknowledged: boolean;
   /** Correlation ID for tracing this update through the control plane */
   correlationId: string;
+  /** Non-null when the update could not be delivered (not connected, timeout, etc.) */
+  error?: string | null;
   /**
    * Populated when the registry immediately resolved a new component based
    * on the state update. In practice this may arrive asynchronously via the

--- a/src/runtime/contracts.ts
+++ b/src/runtime/contracts.ts
@@ -1,0 +1,42 @@
+/**
+ * Local type stubs for @control-plane/contracts
+ *
+ * These mirror daemon/contracts/types.ts exactly. When the daemon repo publishes
+ * @control-plane/contracts to npm, replace this file's content with:
+ *
+ *   export type { Message, ActionRecord, MessageMetadata } from '@control-plane/contracts';
+ *
+ * and update package.json:
+ *   "@control-plane/contracts": "file:../../daemon/contracts"  // dev
+ *   "@control-plane/contracts": "^<version>"                   // published
+ */
+
+/** Metadata threaded through every envelope for correlation and acknowledgement */
+export interface MessageMetadata {
+  correlationId: string;
+  acknowledged: boolean;
+  error: string | null;
+}
+
+/**
+ * The action payload carried inside a Message envelope.
+ * Corresponds to DaemonService's internal ActionRecord shape.
+ */
+export interface ActionRecord {
+  id: string;
+  componentId: string;
+  actionType: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+}
+
+/**
+ * Full Message envelope sent over the graphql-transport-ws connection.
+ * direction / kind drive the daemon's handleAction pipeline.
+ */
+export interface Message {
+  direction: 'ACTION' | 'ECHO' | 'SNAPSHOT' | 'RESOLVE';
+  kind: 'ACTION' | 'ACTION_ECHO' | 'STATE_SNAPSHOT' | 'RESOLVE';
+  payload: ActionRecord;
+  metadata: MessageMetadata;
+}

--- a/src/runtime/graphql-ws-client.ts
+++ b/src/runtime/graphql-ws-client.ts
@@ -1,0 +1,144 @@
+/**
+ * GraphQL WebSocket client for the daemon control plane.
+ *
+ * Wraps an existing graphql-transport-ws connection and adds a fire-and-collect
+ * .mutation() helper used by RemoteMFE.doUpdateControlPlaneState().
+ *
+ * The underlying WebSocket is created and owned by the Renderer (same socket
+ * used for the Subscription.messages channel). RemoteMFE receives it via
+ * BaseMFEDependencies.wsClient.
+ */
+
+/**
+ * Minimal interface for the socket so tests can inject fakes without depending
+ * on the browser WebSocket class.
+ */
+interface MinimalSocket {
+  readonly readyState: number;
+  send(data: string): void;
+  addEventListener(
+    type: 'message',
+    listener: (event: { data: unknown }) => void,
+  ): void;
+  removeEventListener(
+    type: 'message',
+    listener: (event: { data: unknown }) => void,
+  ): void;
+}
+
+/** graphql-transport-ws readyState open value */
+const WS_OPEN = 1;
+
+/**
+ * Platform-facing interface used in BaseMFEDependencies.
+ * Keeps the abstract base class decoupled from the concrete implementation.
+ */
+export interface DaemonWebSocketClient {
+  /** True when the underlying socket is open and ready to send frames. */
+  readonly connected: boolean;
+
+  /**
+   * Execute a GraphQL mutation over the existing WS connection using the
+   * graphql-transport-ws subscribe/next/complete protocol.
+   *
+   * @param query      Full GraphQL mutation string
+   * @param variables  Variables map
+   * @param timeoutMs  Abort after this many ms (default 4 000, matches DaemonService.forwardTimeoutMs)
+   * @returns Resolves with the Boolean result of the mutation
+   * @throws Error on timeout or GraphQL-level errors
+   */
+  mutation(
+    query: string,
+    variables: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<boolean>;
+}
+
+/**
+ * Concrete implementation of DaemonWebSocketClient.
+ *
+ * Protocol sketch for a mutation over graphql-transport-ws:
+ *   1. Client → `{ type: "subscribe", id, payload: { query, variables } }`
+ *   2. Server → `{ type: "next",      id, payload: { data: { <field>: <value> } } }`
+ *   3. Server → `{ type: "complete",  id }`                (server signals done)
+ *   4. Client → `{ type: "complete",  id }`                (client acknowledges)
+ *
+ * We resolve on step 2 (first "next" frame) and send the client-side "complete"
+ * immediately after to free server-side resources.
+ */
+export class GraphQLWebSocketClient implements DaemonWebSocketClient {
+  private readonly socket: MinimalSocket;
+
+  constructor(socket: MinimalSocket) {
+    this.socket = socket;
+  }
+
+  get connected(): boolean {
+    return this.socket.readyState === WS_OPEN;
+  }
+
+  async mutation(
+    query: string,
+    variables: Record<string, unknown>,
+    timeoutMs = 4_000,
+  ): Promise<boolean> {
+    if (!this.connected) {
+      throw new Error('Daemon WebSocket not connected');
+    }
+
+    const id = crypto.randomUUID();
+
+    return new Promise<boolean>((resolve, reject) => {
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.socket.removeEventListener('message', onMessage);
+        reject(new Error('sendMessage timed out'));
+      }, timeoutMs);
+
+      const onMessage = (event: { data: unknown }) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(event.data as string) as Record<string, unknown>;
+        } catch {
+          return; // ignore non-JSON frames
+        }
+
+        if (msg['id'] !== id) return;
+
+        if (msg['type'] === 'next') {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          this.socket.removeEventListener('message', onMessage);
+
+          // Send client-side complete to acknowledge receipt
+          this.socket.send(JSON.stringify({ type: 'complete', id }));
+
+          // Extract the Boolean result from payload.data.<firstField>
+          const payload = msg['payload'] as Record<string, unknown> | undefined;
+          const data = payload?.['data'] as Record<string, unknown> | undefined;
+          const firstValue = data ? Object.values(data)[0] : undefined;
+          resolve(typeof firstValue === 'boolean' ? firstValue : true);
+        } else if (msg['type'] === 'error') {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          this.socket.removeEventListener('message', onMessage);
+
+          const errors = msg['payload'] as Array<{ message?: string }> | undefined;
+          const message = errors?.[0]?.message ?? 'GraphQL mutation error';
+          reject(new Error(message));
+        }
+      };
+
+      this.socket.addEventListener('message', onMessage);
+
+      this.socket.send(
+        JSON.stringify({ type: 'subscribe', id, payload: { query, variables } }),
+      );
+    });
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -36,5 +36,9 @@ export {
   ModuleFederationContainer,
 } from './remote-mfe';
 
+// Daemon WebSocket client (used to wire up the control-plane connection)
+export { GraphQLWebSocketClient } from './graphql-ws-client';
+export type { DaemonWebSocketClient } from './graphql-ws-client';
+
 // Platform handlers (REQ-RUNTIME-005 through REQ-RUNTIME-010)
 export * from './handlers';

--- a/src/runtime/remote-mfe.ts
+++ b/src/runtime/remote-mfe.ts
@@ -10,6 +10,7 @@
 
 import { BaseMFE, LoadResult, RenderResult, Context, HealthResult, DescribeResult, SchemaResult, QueryResult, EmitResult, ControlPlaneStateResult } from './base-mfe';
 import type { DSLManifest } from '../dsl/schema';
+import type { Message, ActionRecord, MessageMetadata } from './contracts';
 
 /**
  * Module Federation container interface
@@ -29,6 +30,8 @@ export class RemoteMFE extends BaseMFE {
   private container: ModuleFederationContainer | null = null;
   private availableComponents: string[] = [];
   private mountedComponent: any = null;
+  /** ID of the currently mounted component; used as actionRecord.componentId */
+  private currentComponentId: string | null = null;
 
   /**
    * Implement load logic for Module Federation remote
@@ -342,6 +345,7 @@ export class RemoteMFE extends BaseMFE {
 
       // Store mounted component reference
       this.mountedComponent = { component: componentName, element, props };
+      this.currentComponentId = componentName;
 
       // Populate context outputs
       context.outputs = {
@@ -570,6 +574,9 @@ export class RemoteMFE extends BaseMFE {
    * Subscription.messages channel the Renderer is already subscribed to.
    */
   protected async doUpdateControlPlaneState(context: Context): Promise<ControlPlaneStateResult> {
+    // -------------------------------------------------------------------------
+    // 1. Extract and validate inputs
+    // -------------------------------------------------------------------------
     const rawStateKey = context.inputs?.stateKey;
     const rawStateData = context.inputs?.stateData;
     const rawCorrelationId = context.inputs?.correlationId;
@@ -594,28 +601,77 @@ export class RemoteMFE extends BaseMFE {
 
     const stateKey = rawStateKey.trim();
     const stateData = (rawStateData ?? {}) as Record<string, unknown>;
-    const correlationId = rawCorrelationId ? rawCorrelationId.trim() : context.requestId;
-    // TODO: send via the daemon WebSocket connection
-    // In a real Module Federation MFE this uses the shared WS client:
-    //
-    // await daemonWsClient.sendAction({
-    //   stateKey,
-    //   stateData,
-    //   correlationId,
-    //   mfe: this.manifest.name,
-    // });
+    const correlationId = (rawCorrelationId as string | undefined)?.trim() ?? context.requestId;
 
+    // -------------------------------------------------------------------------
+    // 2. Guard: daemon WebSocket must be connected
+    // -------------------------------------------------------------------------
+    const wsClient = this.deps?.wsClient;
+    if (!wsClient || !wsClient.connected) {
+      return { acknowledged: false, correlationId, error: 'Daemon WebSocket not connected' };
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. Build the Message envelope typed against @control-plane/contracts
+    // -------------------------------------------------------------------------
+    const metadata: MessageMetadata = {
+      correlationId,
+      acknowledged: false,
+      error: null,
+    };
+
+    const payload: ActionRecord = {
+      id: crypto.randomUUID(),
+      componentId: this.currentComponentId ?? this.manifest.name,
+      actionType: stateKey,
+      data: stateData,
+      timestamp: new Date().toISOString(),
+    };
+
+    const envelope: Message = {
+      direction: 'ACTION',
+      kind: 'ACTION',
+      payload,
+      metadata,
+    };
+
+    // -------------------------------------------------------------------------
+    // 4. Send via the daemon's sendMessage GraphQL mutation (WS subscribe/next)
+    // -------------------------------------------------------------------------
+    let success: boolean;
+    try {
+      success = await wsClient.mutation(
+        'mutation sendMessage($m: String!) { sendMessage(message: $m) }',
+        { m: JSON.stringify(envelope) },
+        4_000,
+      );
+    } catch (err) {
+      const message = (err as Error).message ?? 'sendMessage mutation failed';
+      const error = message.includes('timed out') ? 'sendMessage timed out' : message;
+      return { acknowledged: false, correlationId, error };
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. Telemetry
+    // -------------------------------------------------------------------------
     if (this.deps?.telemetry) {
       this.deps.telemetry.emit({
         name: 'control-plane-state-update',
         capability: 'updateControlPlaneState',
         phase: 'main',
-        status: 'success',
-        metadata: { mfe: this.manifest.name, stateKey, correlationId },
+        status: success ? 'success' : 'error',
+        metadata: { mfe: this.manifest.name, stateKey, correlationId, acknowledged: success },
         timestamp: new Date(),
       });
     }
 
-    return { acknowledged: true, correlationId };
+    // -------------------------------------------------------------------------
+    // 6. Return ControlPlaneStateResult
+    // -------------------------------------------------------------------------
+    return {
+      acknowledged: success,
+      correlationId,
+      error: success ? null : 'sendMessage mutation failed',
+    };
   }
 }


### PR DESCRIPTION
Replaces the stub with a full graphql-transport-ws implementation:

- contracts.ts: local type stubs (Message, ActionRecord, MessageMetadata)
  mirroring daemon/contracts/types.ts — swap for the published
  @control-plane/contracts package once the daemon repo publishes it.

- graphql-ws-client.ts: DaemonWebSocketClient interface + concrete
  GraphQLWebSocketClient class with a .mutation() helper that sends a
  graphql-transport-ws subscribe frame, captures the first next frame,
  sends client-side complete, and times out at 4 000 ms.

- base-mfe.ts: adds error?: string | null to ControlPlaneStateResult;
  adds wsClient?: DaemonWebSocketClient to BaseMFEDependencies; re-exports
  DaemonWebSocketClient for consumers.

- remote-mfe.ts: imports Message/ActionRecord/MessageMetadata from
  contracts; adds currentComponentId field (set on successful render);
  implements doUpdateControlPlaneState() — guards on connection, builds
  the Message envelope with crypto.randomUUID(), sends via
  wsClient.mutation(), catches timeout/network errors as result values
  (no throws), emits telemetry, returns ControlPlaneStateResult.

https://claude.ai/code/session_01VndDQqVwYy4wvamR2d4cpU