### PR TITLE
feat(bff-plugin): scaffold @falese/bff-plugin package skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@babel/parser": "^7.23.0",
         "@babel/traverse": "^7.23.0",
         "@babel/types": "^7.22.1",
+        "@falese/bff-plugin": "file:packages/bff-plugin",
         "@oclif/core": "^4.10.5",
         "@oclif/plugin-help": "^6.2.44",
         "@oclif/plugin-plugins": "^5.4.61",
@@ -3141,6 +3142,10 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@falese/bff-plugin": {
+      "resolved": "packages/bff-plugin",
+      "link": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -12824,6 +12829,33 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/bff-plugin": {
+      "name": "@falese/bff-plugin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@seans-mfe/contracts": "file:../contracts",
+        "@seans-mfe/oclif-base": "file:../oclif-base",
+        "chalk": "^4.1.2",
+        "ejs": "^3.1.10",
+        "fs-extra": "^11.2.0",
+        "js-yaml": "^4.1.0"
+      },
+      "devDependencies": {
+        "@oclif/core": "^4.10.5",
+        "oclif": "^4.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@oclif/core": "^4",
+        "seans-mfe-tool": "^1"
+      },
+      "peerDependenciesMeta": {
+        "seans-mfe-tool": {
+          "optional": true
+        }
       }
     },
     "packages/contracts": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@seans-mfe/contracts": "file:packages/contracts",
     "@seans-mfe/oclif-base": "file:packages/oclif-base",
+    "@falese/bff-plugin": "file:packages/bff-plugin",
     "@apidevtools/swagger-parser": "^10.1.0",
     "@babel/generator": "^7.22.1",
     "@babel/parser": "^7.23.0",

--- a/packages/bff-plugin/package.json
+++ b/packages/bff-plugin/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@falese/bff-plugin",
+  "version": "0.1.0",
+  "description": "BFF commands plugin for seans-mfe-tool (bff:init, bff:validate, bff:build, bff:dev)",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "oclif.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc && npx oclif manifest",
+    "clean": "rm -rf dist oclif.manifest.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "oclif": {
+    "commands": "./dist/commands",
+    "bin": "seans-mfe-tool",
+    "topics": {
+      "bff": {
+        "description": "BFF (Backend-for-Frontend) scaffold and lifecycle commands"
+      }
+    }
+  },
+  "peerDependencies": {
+    "@oclif/core": "^4",
+    "seans-mfe-tool": "^1"
+  },
+  "peerDependenciesMeta": {
+    "seans-mfe-tool": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@seans-mfe/contracts": "file:../contracts",
+    "@seans-mfe/oclif-base": "file:../oclif-base",
+    "chalk": "^4.1.2",
+    "ejs": "^3.1.10",
+    "fs-extra": "^11.2.0",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@oclif/core": "^4.10.5",
+    "typescript": "^5.0.0",
+    "oclif": "^4.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/bff-plugin/src/index.ts
+++ b/packages/bff-plugin/src/index.ts
@@ -1,0 +1,2 @@
+// Placeholder — commands and exports will be added in Issue 2 (migrate shared code, types, templates).
+export {};

--- a/packages/bff-plugin/tsconfig.json
+++ b/packages/bff-plugin/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
+    "paths": {
+      "@seans-mfe/contracts": ["../contracts/src/index.ts"],
+      "@seans-mfe/oclif-base": ["../oclif-base/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #124

## What changed
- Added `packages/bff-plugin/package.json` — name `@falese/bff-plugin`, version `0.1.0`; oclif topic `bff`; peerDeps `@oclif/core ^4` + `seans-mfe-tool ^1` (with `peerDependenciesMeta` marking `seans-mfe-tool` optional so `npm install` succeeds in-workspace without a published package); deps: `@seans-mfe/contracts file:../contracts`, `@seans-mfe/oclif-base file:../oclif-base`, `chalk`, `ejs`, `fs-extra`, `js-yaml`; devDeps: `@oclif/core`, `typescript`, `oclif`
- Added `packages/bff-plugin/tsconfig.json` — mirrors `packages/oclif-base/tsconfig.json`; `composite: true`, `ignoreDeprecations: "5.0"`, `paths` for `@seans-mfe/contracts` and `@seans-mfe/oclif-base` pointing to workspace source
- Added `packages/bff-plugin/src/index.ts` — placeholder `export {}` with comment referencing Issue 2
- Added `"@falese/bff-plugin": "file:packages/bff-plugin"` to root `package.json` dependencies (immediately after the other `file:packages/*` entries)

## Acceptance criteria verification
- [x] `packages/bff-plugin/package.json` exists with correct `name`, `oclif.topics.bff`, peerDeps, and deps as specified — ✅ file created
- [x] `tsc --noEmit -p packages/bff-plugin/tsconfig.json` passes with zero errors — ✅ verified locally
- [x] `packages/bff-plugin/src/index.ts` exists — ✅ file created
- [x] `"@falese/bff-plugin": "file:packages/bff-plugin"` appears in root `package.json` dependencies — ✅ verified
- [x] `npm install` succeeds from repo root — ✅ verified (peer dep `seans-mfe-tool` marked optional to avoid registry lookup)
- [x] All existing tests still pass — ✅ 1434 tests passed
- [x] `npm run typecheck` (root) — ⚠️ pre-existing failures in `packages/contracts/tsconfig.json` and `packages/oclif-base` (visible in `git status` on `main` before this branch was cut); not introduced by this PR

## Verification gates
- [ ] npm run lint — ⚠️ pre-existing ESLint v9 config format issue (unrelated)
- [ ] npm run typecheck — ⚠️ pre-existing failures (see above)
- [x] npm test — ✅ 1434 passed, 63 suites
- [ ] npm run build — ⚠️ blocked by pre-existing typecheck failures
- [ ] npm run build:schemas — N/A (no command flags/args/return types changed)

## Files touched
- `packages/bff-plugin/package.json` (new)
- `packages/bff-plugin/tsconfig.json` (new)
- `packages/bff-plugin/src/index.ts` (new)
- `package.json` (root deps — one line added)

## Decisions and deviations
- Added `peerDependenciesMeta.seans-mfe-tool.optional: true` to prevent npm from attempting a registry fetch for the in-workspace root package. The peer dependency declaration is preserved for documentation and runtime contract purposes. This follows the bundled-plugin pattern where the host CLI already provides the peer at runtime.