### PR TITLE
feat(adr-071): Phase 4 close-out — open schema, unified remote:init, plugin authoring guide (#181, #182, #185)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ ADR quick index: `@docs/spec.md#adr-index`
 | oclif migration (Epics A + B + C, PR #123) | ✅ Done |
 | Codegen + DSL pipeline | ✅ Done |
 | GraphQL BFF layer | ✅ Done |
+| Framework plugin system (ADR-071, #167–#185, PRs #187–#188) | ✅ Done |
 | Runtime platform (REQ-RUNTIME-001–012) | 🟡 In Progress (issues #47–59) |
 | BaseMFE boilerplate codegen from DSL (REQ-057) | 🟡 In Progress (issue #39) |
 | Lifecycle engine enhancements (ADR-063–067) | 📋 Planned (issues not yet created) |
@@ -97,6 +98,11 @@ See `docs/PROJECT-STATUS.md` for priority order and blockers.
 | Codegen templates | `src/codegen/templates/` |
 | Plugin skeleton | `examples/plugin-skeleton/` |
 | ADRs | `docs/architecture-decisions/` |
+| Framework plugin base | `packages/contracts/src/framework-plugin.ts` |
+| Framework plugin loader | `src/framework/loader.ts` |
+| React plugin | `packages/framework-react/src/plugin.ts` |
+| Angular plugin | `packages/framework-angular/src/plugin.ts` |
+| Plugin authoring guide | `docs/framework-plugin-authoring.md` |
 
 ## Resolved decisions — do not relitigate
 
@@ -105,6 +111,8 @@ See `docs/PROJECT-STATUS.md` for priority order and blockers.
 - **MCP child-process per tool call.** Spawn `seans-mfe-tool <cmd> --json`. Isolates `process.exit` and cwd mutations; concurrency-safe.
 - **Bun for dev, Node for publish.** `bin/dev.ts` / `bin/run.js` split is permanent.
 - **Framework-agnostic codegen.** `framework` and `bundler` are DSL manifest fields; new framework support = new template variant (ADR-069).
+- **Framework plugins, not hardcoded variants.** `build:dev`, `build:prod`, `build:docker`, `build:check`, `remote:init`, and `deploy` all resolve the framework via `loadFrameworkPlugin()` (ADR-071). Adding a new framework = publishing `@seans-mfe/framework-<name>`.
+- **Open schema for framework/bundler.** `FrameworkSchema` and `BundlerSchema` are `z.string().min(1)` — not enums. Unknown values emit a stderr warning; they are not validation errors (ADR-071, #181).
 
 ## Backlog priority
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ See [PLUGIN-CONTRACT.md](./PLUGIN-CONTRACT.md) for the full integration spec
 and [`examples/plugin-skeleton/`](./examples/plugin-skeleton/) for a working
 starter plugin you can clone and rename.
 
+To add support for a new UI framework (Vue, Svelte, Solid, etc.), see the
+[Framework Plugin Authoring Guide](./docs/framework-plugin-authoring.md) — it
+covers extending `BaseFrameworkPlugin`, publishing `@seans-mfe/framework-<name>`,
+and a complete `vue-vite` skeleton.
+
 For the long-term roadmap toward a unified monorepo, see [MERGE-PLAN.md](./MERGE-PLAN.md).
 
 ---

--- a/docs/framework-plugin-authoring.md
+++ b/docs/framework-plugin-authoring.md
@@ -1,0 +1,297 @@
+# Framework Plugin Authoring Guide
+
+This guide explains how to create a custom framework plugin for `seans-mfe-tool` by extending `BaseFrameworkPlugin`. Once published, your plugin is automatically discovered by `loadFrameworkPlugin()` and wired into `build:dev`, `build:prod`, `build:docker`, `build:check`, `remote:init`, and `deploy`.
+
+**Governing ADR:** ADR-071  
+**Type definitions:** `packages/contracts/src/framework-plugin.ts`  
+**Reference implementation:** `packages/framework-react/src/plugin.ts`
+
+---
+
+## Overview
+
+The plugin system separates _what to build_ (the framework/bundler combination) from _how the CLI orchestrates_ it. Each plugin:
+
+- Describes its identity (`id`, `framework`, `bundler`)
+- Provides scaffolding defaults (`defaultPort`, `directoryStructure`, `getRuntimeDependencies`)
+- Generates codegen variables (`getTemplateVars`, `getSharedDependencies`)
+- Implements the build lifecycle (`checkEnvironment`, `startDevServer`, `buildProduction`, `getDockerStrategy`)
+
+---
+
+## Naming convention
+
+| Concept | Convention | Example |
+|---|---|---|
+| npm package | `@seans-mfe/framework-<name>` | `@seans-mfe/framework-vue` |
+| Plugin `id` | `<framework>-<bundler>` | `vue-vite` |
+| Named export | `frameworkPlugin` | `export const frameworkPlugin = new VueVitePlugin()` |
+
+`loadFrameworkPlugin('vue')` resolves `@seans-mfe/framework-vue` and reads the `frameworkPlugin` export.
+
+---
+
+## Implementing `BaseFrameworkPlugin`
+
+Import the abstract class from `@seans-mfe/contracts`:
+
+```ts
+import {
+  BaseFrameworkPlugin,
+  type EnvCheckResult,
+  type SharedDep,
+  type DockerStrategy,
+  type BuildResult,
+  type DevServerHandle,
+} from '@seans-mfe/contracts';
+```
+
+Your class must implement every abstract member. Here is the full contract with the expected return type for each method:
+
+### Identity
+
+```ts
+readonly id: string           // unique slug, e.g. 'vue-vite'
+readonly displayName: string  // human label, e.g. 'Vue 3 + Vite'
+readonly framework: string    // manifest 'framework' field, e.g. 'vue'
+readonly bundler: string      // manifest 'bundler' field, e.g. 'vite'
+```
+
+### Scaffolding
+
+```ts
+readonly defaultPort: number              // default dev server port
+readonly directoryStructure: string[]     // dirs created by remote:init
+
+getRuntimeDependencies(): Record<string, string>
+// Returns { '<pkg>': '<semver>' } seeded into mfe-manifest.yaml on init.
+```
+
+### Codegen
+
+```ts
+getTemplateDir(): string
+// Absolute path to the EJS template directory. Must exist at runtime.
+// Convention: path.resolve(__dirname, '../../..', 'src/codegen/templates/base-mfe-<name>')
+
+getTemplateVars(manifest: unknown): Record<string, unknown>
+// Extra variables merged into EJS rendering context.
+
+getRuntimeImport(): string     // e.g. '@seans-mfe-tool/runtime'
+getRuntimeClassName(): string  // e.g. 'RemoteMFE'
+getSourceExtension(): string   // e.g. '.tsx'
+getTestExtension(): string     // e.g. '.test.tsx'
+
+getSharedDependencies(manifest: unknown): SharedDep[]
+// Module Federation singleton declarations. Return [] for non-MF targets.
+// SharedDep: { name, singleton, requiredVersion, eager?, strictVersion? }
+```
+
+### Build lifecycle
+
+```ts
+checkEnvironment(): Promise<EnvCheckResult[]>
+// One EnvCheckResult per required tool: { tool, required, found, ok, fix? }
+// 'ok: false' causes build:check to exit non-zero.
+
+startDevServer(manifest: unknown, opts: { port: number; cwd: string }): Promise<DevServerHandle>
+// Start the dev server and return a handle. Block until stop() is called.
+// DevServerHandle: { url: string; stop: () => Promise<void> }
+
+buildProduction(manifest: unknown, opts: { cwd: string; outputDir: string }): Promise<BuildResult>
+// Run the production build. Never throw — return success:false with errors[] instead.
+// BuildResult: { success, artifacts, duration_ms, warnings, errors: BuildError[] }
+
+getDockerStrategy(manifest: unknown): DockerStrategy
+// Describe the multi-stage Docker build.
+// DockerStrategy: { builderImage, runtimeImage, buildCommands, artifactPaths, cmd,
+//                   needsCliBuilder, healthcheck? }
+// Set needsCliBuilder:true if your MFE uses @seans-mfe-tool/runtime (virtually all do).
+```
+
+---
+
+## Skeleton — `vue-vite` plugin
+
+```ts
+// packages/framework-vue/src/plugin.ts
+import * as path from 'path';
+import { execSync } from 'child_process';
+import {
+  BaseFrameworkPlugin,
+  type EnvCheckResult,
+  type SharedDep,
+  type DockerStrategy,
+  type BuildResult,
+  type DevServerHandle,
+} from '@seans-mfe/contracts';
+
+export class VueVitePlugin extends BaseFrameworkPlugin {
+  readonly id = 'vue-vite';
+  readonly displayName = 'Vue 3 + Vite';
+  readonly framework = 'vue';
+  readonly bundler = 'vite';
+  readonly defaultPort = 3201;
+  readonly directoryStructure = ['src', 'src/features', 'public'];
+
+  getRuntimeDependencies() {
+    return { 'vue': '^3.4.0' };
+  }
+
+  getTemplateDir() {
+    return path.resolve(__dirname, '../../..', 'src/codegen/templates/base-mfe-vue');
+  }
+
+  getTemplateVars(_manifest: unknown) {
+    return { framework: 'vue', bundler: 'vite', templateVariant: 'vue-vite' };
+  }
+
+  getRuntimeImport() { return '@seans-mfe-tool/runtime'; }
+  getRuntimeClassName() { return 'RemoteMFE'; }
+  getSourceExtension() { return '.vue'; }
+  getTestExtension() { return '.test.ts'; }
+
+  getSharedDependencies(_manifest: unknown): SharedDep[] {
+    return [{ name: 'vue', singleton: true, requiredVersion: '^3.4.0', eager: true }];
+  }
+
+  async checkEnvironment(): Promise<EnvCheckResult[]> {
+    try {
+      const v = execSync('node --version', { encoding: 'utf8' }).trim().replace(/^v/, '');
+      return [{ tool: 'node', required: '>=18', found: v, ok: parseInt(v) >= 18 }];
+    } catch {
+      return [{ tool: 'node', required: '>=18', found: null, ok: false, fix: 'https://nodejs.org' }];
+    }
+  }
+
+  async startDevServer(_manifest: unknown, opts: { port: number; cwd: string }): Promise<DevServerHandle> {
+    const { spawn } = await import('child_process');
+    const proc = spawn('npx', ['vite', '--port', String(opts.port)], {
+      cwd: opts.cwd, stdio: 'inherit', shell: true,
+    });
+    return {
+      url: `http://localhost:${opts.port}`,
+      stop: () => new Promise<void>((resolve) => {
+        proc.on('close', () => resolve());
+        proc.kill('SIGTERM');
+      }),
+    };
+  }
+
+  async buildProduction(_manifest: unknown, opts: { cwd: string; outputDir: string }): Promise<BuildResult> {
+    const start = Date.now();
+    try {
+      execSync('npx vite build', { cwd: opts.cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+      return { success: true, artifacts: [opts.outputDir], duration_ms: Date.now() - start, warnings: [], errors: [] };
+    } catch (err: unknown) {
+      return {
+        success: false, artifacts: [], duration_ms: Date.now() - start, warnings: [],
+        errors: [{ message: (err as { stderr?: string }).stderr ?? String(err), category: 'unknown' }],
+      };
+    }
+  }
+
+  getDockerStrategy(_manifest: unknown): DockerStrategy {
+    return {
+      builderImage: 'node:20-slim',
+      runtimeImage: 'nginx:alpine',
+      buildCommands: ['npm ci', 'npm run build'],
+      artifactPaths: ['dist/'],
+      cmd: ['nginx', '-g', 'daemon off;'],
+      needsCliBuilder: true,
+      healthcheck: 'wget -qO- http://127.0.0.1:80/ || exit 1',
+    };
+  }
+}
+
+export const frameworkPlugin = new VueVitePlugin();
+```
+
+---
+
+## Package structure
+
+```
+@seans-mfe/framework-vue/
+├── src/
+│   ├── plugin.ts          # VueVitePlugin class + frameworkPlugin export
+│   └── index.ts           # re-exports plugin.ts
+├── src/codegen/templates/
+│   └── base-mfe-vue/      # EJS templates (rspack.config.js.ejs, package.json.ejs, …)
+├── package.json
+└── tsconfig.json
+```
+
+**`package.json` required fields:**
+
+```json
+{
+  "name": "@seans-mfe/framework-vue",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": { "require": "./dist/index.js", "import": "./dist/index.mjs" }
+  },
+  "peerDependencies": {
+    "@seans-mfe/contracts": ">=0.1.0"
+  }
+}
+```
+
+**`index.ts`:**
+
+```ts
+export { VueVitePlugin, frameworkPlugin } from './plugin';
+```
+
+The `frameworkPlugin` named export is **required** — `loadFrameworkPlugin()` reads `mod.frameworkPlugin`.
+
+---
+
+## Template directory
+
+`getTemplateDir()` must return an absolute path to a directory of EJS templates. The built-in templates at `src/codegen/templates/base-mfe/` (React) and `src/codegen/templates/base-mfe-angular/` (Angular) are good references.
+
+Minimum template files for a remote MFE:
+
+```
+base-mfe-vue/
+├── package.json.ejs       # project dependencies
+├── vite.config.js.ejs     # bundler + Module Federation config
+├── mfe.ts.ejs             # BaseMFE subclass
+├── mfe.test.ts.ejs        # unit test stub
+└── features/
+    ├── index.ts.ejs
+    └── remote.vue.ejs     # exposed component
+```
+
+Available template variables (always present):
+
+| Variable | Source |
+|---|---|
+| `name` | MFE name |
+| `port` | resolved port |
+| `framework` | `plugin.framework` |
+| `bundler` | `plugin.bundler` |
+| `templateVariant` | `plugin.id` |
+| `...getTemplateVars(manifest)` | your plugin |
+
+---
+
+## Publishing
+
+1. Build the package: `tsc`
+2. `npm publish --access public`
+3. Users install: `npm install @seans-mfe/framework-vue`
+4. Users run: `seans-mfe-tool remote:init my-mfe --framework vue`
+
+`loadFrameworkPlugin('vue')` will resolve `@seans-mfe/framework-vue` automatically.
+
+---
+
+## Reference
+
+- **ADR-071** — `docs/architecture-decisions/ADR-071-*.md`
+- **Type definitions** — `packages/contracts/src/framework-plugin.ts`
+- **React reference impl** — `packages/framework-react/src/plugin.ts`
+- **Angular reference impl** — `packages/framework-angular/src/plugin.ts`
+- **Plugin loader** — `src/framework/loader.ts`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -242,6 +242,7 @@ All architecture decisions live in `docs/architecture-decisions/`. **Before impl
 | ADR-068 | Two-headed giant — AI-native + human-legible developer experience | Developer model |
 | ADR-069 | Pluggable bundler + framework via codegen variants | Codegen / polyglot |
 | ADR-070 | Docker build orchestration via Turborepo task graph | Docker / CI |
+| ADR-071 | Framework plugin system — `BaseFrameworkPlugin` + `loadFrameworkPlugin()` | Build commands, codegen, deploy |
 
 `docs/architecture-decisions/architecture-decisions.md` is the narrative index with rationale.
 

--- a/session-prompt.md
+++ b/session-prompt.md
@@ -4,11 +4,14 @@
 
 ### Active issue(s)
 
-**[#178](https://github.com/falese/seans-mfe-tool/issues/178) + [#179](https://github.com/falese/seans-mfe-tool/issues/179) — Phase 3 close-out (ADR-071)**
+**ADR-071 Phase 4 close-out — #181, #185, #182**
 
-#178: Migrate deploy Docker templates → plugin (`dockerComposeProductionDeploy`, lines 348–354)
-#179: Cross-runtime MF compatibility smoke test (React rspack ↔ Angular webpack)
+Validated state: #180 (contracts exports) and #172 (build:check) were already done and closed.
+
+#181: Extend DSL schema — `FrameworkSchema`/`BundlerSchema` from `z.enum` to `z.string().min(1)` with stderr warning on unknown values
+#185: Remove hardcoded `options: ['react', 'angular']` from `remote:init --framework` flag
+#182: Write `docs/framework-plugin-authoring.md` (vue-vite skeleton, all abstract methods, publishing guide)
 
 ### ADR check
 
-ADR-071 governs both issues.
+ADR-071 governs all three issues.

--- a/session-prompt.md
+++ b/session-prompt.md
@@ -1,17 +1,71 @@
 # seans-mfe-tool — Session Prompt
 
+> Update this file before each coding session. Hand it to the agent alongside CLAUDE.md.
+> Keep CLAUDE.md open in every session. Reference @docs/spec.md only for sections relevant
+> to the active issue.
+
+---
+
+## How to use this template
+
+1. Fill in **Active issue** and **Scope** below
+2. Run the ADR check — confirm which existing ADRs govern this work; if none exist for a decision, stop and create one (or waive explicitly)
+3. Copy the relevant spec sections from `@docs/spec.md` into **Spec context**
+4. Update **Current file tree** to reflect actual state
+5. Hand `CLAUDE.md` + this file to the coding agent
+6. After the session, update **Current state** in `CLAUDE.md` and any resolved decisions in `docs/spec.md`
+
+---
+
 ## Session: 2026-05-24
 
 ### Active issue(s)
 
-**ADR-071 Phase 4 close-out — #181, #185, #182**
+**ADR-071 Phase 4 close-out — [#181](https://github.com/falese/seans-mfe-tool/issues/181), [#185](https://github.com/falese/seans-mfe-tool/issues/185), [#182](https://github.com/falese/seans-mfe-tool/issues/182)**
 
-Validated state: #180 (contracts exports) and #172 (build:check) were already done and closed.
+Validated at session start: #180 (contracts exports) and #172 (build:check) were already done and closed.
 
-#181: Extend DSL schema — `FrameworkSchema`/`BundlerSchema` from `z.enum` to `z.string().min(1)` with stderr warning on unknown values
-#185: Remove hardcoded `options: ['react', 'angular']` from `remote:init --framework` flag
-#182: Write `docs/framework-plugin-authoring.md` (vue-vite skeleton, all abstract methods, publishing guide)
+### Scope
+
+#181: `FrameworkSchema` / `BundlerSchema` in `src/dsl/schema.ts` changed from `z.enum` to `z.string().min(1)`. `KNOWN_FRAMEWORKS` / `KNOWN_BUNDLERS` constants exported for use in warnings. `parseManifestFile` in `src/dsl/parser.ts` emits a stderr warning (not error) for unknown values.
+
+#185: `remote:init --framework` flag drops the hardcoded `options: ['react', 'angular']` list. Any string accepted by oclif; unknown frameworks fail at `loadFrameworkPlugin()` with `ValidationError`. Type cast `as 'react' | 'angular'` removed from `init.ts`.
+
+#182: New `docs/framework-plugin-authoring.md` — full guide for third-party plugin authors. Covers all abstract methods, VueVitePlugin skeleton, template directory conventions, npm package structure, and publishing steps. Link added to `README.md`.
+
+NOT changing: existing plugin implementations, build commands, deploy logic, abc-kids examples.
+
+**Acceptance criteria:**
+- `FrameworkSchema.parse('svelte')` passes without error
+- Unknown framework in manifest → warning on stderr, no schema error
+- `remote:init --framework vue` → `ValidationError` from loader (not oclif)
+- `docs/framework-plugin-authoring.md` exists with vue-vite skeleton
+- All existing tests pass (2 pre-existing failures in cli-workflow + codegen-workflow are unrelated)
 
 ### ADR check
 
-ADR-071 governs all three issues.
+| ADR | Title | Governs |
+|-----|-------|---------|
+| ADR-071 | Framework plugin pattern (`BaseFrameworkPlugin`) | All Phase 4 issues |
+
+### Spec context
+
+From ADR-071:
+> Third-party plugins live at `@seans-mfe/framework-<name>` and are resolved by `loadFrameworkPlugin()`.
+> The schema must accept arbitrary framework/bundler strings so plugin authors don't need to fork the core.
+
+### Current branch
+
+`claude/phase4-adr071-close-out` — PR #188 open against `main`.
+
+### Key files modified this session
+
+| File | Change |
+|---|---|
+| `src/dsl/schema.ts` | `FrameworkSchema`/`BundlerSchema` → open string; `KNOWN_*` constants |
+| `src/dsl/parser.ts` | `warnUnknownPluginValues()` added to `parseManifestFile` |
+| `src/commands/remote/init.ts` | Removed `options:[]` list + type cast |
+| `src/dsl/__tests__/validator.test.ts` | 2 tests flipped to expect acceptance of unknown values |
+| `src/commands/__tests__/remote-init.test.ts` | New test: unknown framework → `ValidationError` |
+| `docs/framework-plugin-authoring.md` | New — full authoring guide |
+| `README.md` | Link to authoring guide |

--- a/src/commands/__tests__/remote-init.test.ts
+++ b/src/commands/__tests__/remote-init.test.ts
@@ -114,6 +114,15 @@ describe('remote:init Command', () => {
       await expect(remoteInitCommand('my-feature', { skipInstall: true })).rejects.toThrow(/Failed to create directory:/);
       expect(mockConsole.error).toHaveBeenCalledWith(expect.stringContaining('Failed to create'));
     });
+
+    it('unknown framework reaches loadFrameworkPlugin and throws ValidationError (ADR-071, #185)', async () => {
+      // The --framework flag no longer has a hardcoded options list; any string is accepted by oclif.
+      // loadFrameworkPlugin throws ValidationError when the plugin is not installed.
+      const { ValidationError } = await import('@seans-mfe/contracts');
+      await expect(
+        remoteInitCommand('test-vue', { skipInstall: true, framework: 'vue' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
   });
 
   describe('Console Output', () => {

--- a/src/commands/remote/init.ts
+++ b/src/commands/remote/init.ts
@@ -66,8 +66,8 @@ export async function remoteInitCommand(
     const manifest = createMinimalManifest(name, {
       type: 'remote',
       language: 'typescript',
-      framework: plugin.framework as 'react' | 'angular',
-      bundler: plugin.bundler as 'rspack' | 'webpack',
+      framework: plugin.framework,
+      bundler: plugin.bundler,
     });
     const endpoints = generateEndpoints(name, port);
     const fullManifest: DSLManifest = { ...manifest, ...endpoints };
@@ -110,9 +110,8 @@ export default class RemoteInit extends BaseCommand<RemoteInitResult> {
   static flags = {
     ...BaseCommand.baseFlags,
     framework: Flags.string({
-      description: 'Framework to use (default: react)',
+      description: 'Framework to use (default: react). Install @seans-mfe/framework-<name> for third-party frameworks.',
       default: 'react',
-      options: ['react', 'angular'],
     }),
     port: Flags.string({
       char: 'p',

--- a/src/dsl/__tests__/validator.test.ts
+++ b/src/dsl/__tests__/validator.test.ts
@@ -141,7 +141,8 @@ describe('DSL Validator', () => {
       expect(result.manifest?.bundler).toBe('webpack');
     });
 
-    it('should reject unknown framework', () => {
+    it('accepts unknown framework (open enum — ADR-071, #181)', () => {
+      // Third-party plugins register new frameworks; schema must not reject them.
       const manifest = {
         name: 'oddball',
         version: '1.0.0',
@@ -152,11 +153,10 @@ describe('DSL Validator', () => {
       };
 
       const result = validateManifest(manifest);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.path.includes('framework'))).toBe(true);
+      expect(result.valid).toBe(true);
     });
 
-    it('should reject unknown bundler', () => {
+    it('accepts unknown bundler (open enum — ADR-071, #181)', () => {
       const manifest = {
         name: 'oddball',
         version: '1.0.0',
@@ -167,8 +167,7 @@ describe('DSL Validator', () => {
       };
 
       const result = validateManifest(manifest);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.path.includes('bundler'))).toBe(true);
+      expect(result.valid).toBe(true);
     });
   });
 

--- a/src/dsl/parser.ts
+++ b/src/dsl/parser.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
 import type { DSLManifest, ValidationResult } from './schema';
+import { KNOWN_FRAMEWORKS, KNOWN_BUNDLERS } from './schema';
 import { validateManifest, validateFull } from './validator';
 
 // =============================================================================
@@ -62,13 +63,29 @@ export function parseYAML(content: string): DSLManifest {
  */
 export async function parseManifestFile(manifestPath: string): Promise<DSLManifest> {
   const absolutePath = path.resolve(process.cwd(), manifestPath);
-  
+
   if (!await fs.pathExists(absolutePath)) {
     throw new Error(`Manifest not found: ${absolutePath}`);
   }
-  
+
   const content = await fs.readFile(absolutePath, 'utf8');
-  return parseYAML(content);
+  const manifest = parseYAML(content);
+  warnUnknownPluginValues(manifest);
+  return manifest;
+}
+
+function warnUnknownPluginValues(manifest: DSLManifest): void {
+  if (manifest.framework && !(KNOWN_FRAMEWORKS as readonly string[]).includes(manifest.framework)) {
+    process.stderr.write(
+      `[seans-mfe-tool] Warning: unknown framework "${manifest.framework}". ` +
+      `Install the plugin: npm install @seans-mfe/framework-${manifest.framework}\n`,
+    );
+  }
+  if (manifest.bundler && !(KNOWN_BUNDLERS as readonly string[]).includes(manifest.bundler)) {
+    process.stderr.write(
+      `[seans-mfe-tool] Warning: unknown bundler "${manifest.bundler}".\n`,
+    );
+  }
 }
 
 /**

--- a/src/dsl/schema.ts
+++ b/src/dsl/schema.ts
@@ -29,12 +29,18 @@ export const LanguageSchema = z.enum([
 ]);
 export type Language = z.infer<typeof LanguageSchema>;
 
-/** Supported UI frameworks (omit ⇒ react). */
-export const FrameworkSchema = z.enum(['react', 'angular']);
+/** Known built-in frameworks — used for validation warnings, not hard errors (ADR-071, #181). */
+export const KNOWN_FRAMEWORKS = ['react', 'angular'] as const;
+
+/** Known built-in bundlers — used for validation warnings, not hard errors (ADR-071, #181). */
+export const KNOWN_BUNDLERS = ['rspack', 'webpack'] as const;
+
+/** UI framework — open string so third-party plugins can register new values (ADR-071, #181). */
+export const FrameworkSchema = z.string().min(1);
 export type Framework = z.infer<typeof FrameworkSchema>;
 
-/** Supported bundlers (omit ⇒ rspack). */
-export const BundlerSchema = z.enum(['rspack', 'webpack']);
+/** Bundler — open string so third-party plugins can register new values (ADR-071, #181). */
+export const BundlerSchema = z.string().min(1);
 export type Bundler = z.infer<typeof BundlerSchema>;
 
 /** Capability type discrimination */


### PR DESCRIPTION
## Summary

Phase 4 of ADR-071. Closes the last three open issues. #180 (contracts exports) and #172 (build:check) were already done and have been closed.

| Issue | What shipped |
|---|---|
| #181 | `FrameworkSchema` / `BundlerSchema` changed from `z.enum` to `z.string().min(1)` — third-party frameworks no longer rejected by schema; stderr warning emitted for unknown values |
| #185 | `remote:init --framework` drops the hardcoded `options: ['react', 'angular']` list — any installed plugin name is accepted; `as 'react' \| 'angular'` cast removed |
| #182 | `docs/framework-plugin-authoring.md` — full authoring guide with VueVitePlugin skeleton, all abstract methods, template structure, publishing steps |

**Governing ADR:** ADR-071

---

## What changed

### `src/dsl/schema.ts`
- `KNOWN_FRAMEWORKS` and `KNOWN_BUNDLERS` constants added (used for warnings, not validation)
- `FrameworkSchema` → `z.string().min(1)` (was `z.enum(['react', 'angular'])`)
- `BundlerSchema` → `z.string().min(1)` (was `z.enum(['rspack', 'webpack'])`)

### `src/dsl/parser.ts`
- `parseManifestFile` now calls `warnUnknownPluginValues()` — writes to `process.stderr` (not stdout) when `framework`/`bundler` are set to unknown values

### `src/commands/remote/init.ts`
- Removed `options: ['react', 'angular']` from `--framework` flag
- Removed `as 'react' | 'angular'` cast on `plugin.framework` / `plugin.bundler`

### `docs/framework-plugin-authoring.md` (new)
- Complete third-party plugin authoring guide with VueVitePlugin skeleton

### `README.md`
- Link to authoring guide added under "Building a plugin"

### Tests updated
- `src/dsl/__tests__/validator.test.ts` — 2 tests flipped from "should reject unknown" → "accepts unknown"
- `src/commands/__tests__/remote-init.test.ts` — new test: `--framework vue` reaches `loadFrameworkPlugin('vue')` and throws `ValidationError` (not oclif flag error)

---

## Checklist

- [x] `npm test` — 1690 pass, 2 fail (pre-existing `cli-workflow` + `codegen-workflow`)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean (pre-existing TS6059 rootDir errors unchanged)
- [x] `npm run build` — clean
- [x] No `any` types
- [x] All commits reference ADR-071 and issue numbers

Closes #181, #182, #185
Refs ADR-071