### PR TITLE
feat: ADR-071 Phase 4 close-out + runtime REQ-RUNTIME-003 + codegen BFF fixes

### DIFF
--- a/packages/bff-plugin/templates/Dockerfile.ejs
+++ b/packages/bff-plugin/templates/Dockerfile.ejs
@@ -47,10 +47,8 @@ WORKDIR /app
 # so --omit=dev correctly skips @seans-mfe-tool/runtime resolution entirely.
 COPY --from=builder /app/package.json ./
 RUN npm install --omit=dev --legacy-peer-deps --no-audit --no-fund
-<% if (hasData) { %>
 # Copy Mesh artifacts
 COPY --from=builder /app/.mesh ./.mesh
-<% } %>
 <% if (includeStatic) { %>
 # Copy built static assets
 COPY --from=builder /app/dist ./dist

--- a/packages/bff-plugin/templates/server.ts.ejs
+++ b/packages/bff-plugin/templates/server.ts.ejs
@@ -8,8 +8,8 @@ import express from 'express';
 import path from 'path';
 import cors from 'cors';
 import helmet from 'helmet';
-<% if (hasData) { %>import { createBuiltMeshHTTPHandler } from './.mesh';
-<% } %>import type { Request, Response, NextFunction, Express } from 'express';
+import { createBuiltMeshHTTPHandler } from './.mesh';
+import type { Request, Response, NextFunction, Express } from 'express';
 import crypto from 'crypto';
 
 const app: Express = express();
@@ -55,7 +55,7 @@ app.get('/health', (req: express.Request, res: express.Response) => {
 // GraphQL BFF endpoint (Mesh v0.100.x)
 // Following REQ-BFF-003: JWT Authentication Forwarding
 // Following ADR-062: createBuiltMeshHTTPHandler pattern
-<% if (hasData) { %>interface MeshContext {
+interface MeshContext {
   jwt?: string;
   requestId: string;
   userId?: string;
@@ -72,14 +72,13 @@ app.use('/graphql', (req: Request, res: Response) => {
     requestId: (req.headers['x-request-id'] as string) || crypto.randomUUID(),
     userId: extractUserIdFromToken(req.headers.authorization as string),
   };
-  
+
   // Mesh handler from @whatwg-node/server expects Request/Response objects
   // We need to pass context via the request object
   const requestWithContext = Object.assign(req, { context });
-  
+
   return meshHandler(requestWithContext as any, res as any, context);
 });
-<% } %>
 
 <% if (includeStatic) { %>
 // Static MFE assets

--- a/src/codegen/UnifiedGenerator/__tests__/unified-generator.test.ts
+++ b/src/codegen/UnifiedGenerator/__tests__/unified-generator.test.ts
@@ -348,4 +348,40 @@ describe('unified-generator', () => {
       expect(serverTs!.overwrite).toBe(true);
     });
   });
+
+  describe('BFF files omitted when manifest has no data: section (#149)', () => {
+    const noDataManifest = {
+      name: 'NoDataMFE',
+      version: '1.0.0',
+      description: 'Manifest with no data section',
+      endpoint: 'http://localhost:3001',
+      capabilities: [{ Health: { type: 'platform', description: 'Health check' } }],
+      dependencies: { 'design-system': { '@mui/material': '^5.15.0' }, mfes: {} },
+      // no data: key
+    };
+
+    it('does not emit bff.ts when manifest has no data section', async () => {
+      const files = await generateAllFiles(noDataManifest as any, basePath, { force: true });
+      const bffTs = files.find((f) => f.path.includes('bff.ts') && !f.path.includes('bff.test'));
+      expect(bffTs).toBeUndefined();
+    });
+
+    it('does not emit bff.test.ts when manifest has no data section', async () => {
+      const files = await generateAllFiles(noDataManifest as any, basePath, { force: true });
+      const bffTest = files.find((f) => f.path.includes('bff.test.ts'));
+      expect(bffTest).toBeUndefined();
+    });
+
+    it('does not emit server.ts when manifest has no data section', async () => {
+      const files = await generateAllFiles(noDataManifest as any, basePath, { force: true });
+      const serverTs = files.find((f) => f.path === path.join(basePath, 'server.ts'));
+      expect(serverTs).toBeUndefined();
+    });
+
+    it('does not emit .meshrc.yaml when manifest has no data section', async () => {
+      const files = await generateAllFiles(noDataManifest as any, basePath, { force: true });
+      const meshrc = files.find((f) => f.path.includes('.meshrc.yaml'));
+      expect(meshrc).toBeUndefined();
+    });
+  });
 });

--- a/src/codegen/UnifiedGenerator/__tests__/unified-generator.test.ts
+++ b/src/codegen/UnifiedGenerator/__tests__/unified-generator.test.ts
@@ -177,14 +177,24 @@ describe('unified-generator', () => {
       ...manifest,
       endpoint: 'http://localhost:3002'
     };
-    
+
     const files = await generateAllFiles(manifestWithPort as any, basePath, { force: true });
     const dockerfile = files.find(f => f.path === path.join(basePath, 'Dockerfile'));
-    
+
     expect(dockerfile).toBeDefined();
     // BFF port should be 4002 (3002 + 1000)
     expect(dockerfile?.content).toContain('EXPOSE 4002');
     expect(dockerfile?.content).toContain('http://localhost:4002/health');
+  });
+
+  it('Dockerfile always includes .mesh artifact copy — no hasData conditional (#189)', async () => {
+    // Dockerfile is only emitted when manifest.data exists (fixed in #149).
+    // Within that block hasData is always true, so the template must not
+    // use a conditional — the .mesh COPY step should always be present.
+    const files = await generateAllFiles(manifest as any, basePath, { force: true });
+    const dockerfile = files.find((f) => f.path === path.join(basePath, 'Dockerfile'));
+    expect(dockerfile).toBeDefined();
+    expect(dockerfile!.content).toContain('COPY --from=builder /app/.mesh ./.mesh');
   });
 
   it('generates docker-compose.yaml with correct BFF port', async () => {

--- a/src/codegen/UnifiedGenerator/unified-generator.ts
+++ b/src/codegen/UnifiedGenerator/unified-generator.ts
@@ -799,7 +799,7 @@ export async function generateAllFiles(
     for (const { tpl, out, overwrite } of bffTemplates) {
       const templatePath = path.join(bffTemplateDir, tpl);
       if (await fs.pathExists(templatePath)) {
-        const content = await renderTemplate(templatePath, { ...vars, port: bffPort, includeStatic, hasData: true });
+        const content = await renderTemplate(templatePath, { ...vars, port: bffPort, includeStatic });
         files.push({
           path: path.join(basePath, out),
           content,

--- a/src/codegen/UnifiedGenerator/unified-generator.ts
+++ b/src/codegen/UnifiedGenerator/unified-generator.ts
@@ -746,64 +746,66 @@ export async function generateAllFiles(
     overwrite: true,
   });
 
-  // BFF stub files
-  files.push({
-    path: path.join(bffDir, 'bff.ts'),
-    content: await renderTemplate(path.join(bffTemplateDir, 'bff.ts.ejs'), {
-      ...vars,
-      bffClassName: vars.className + 'BFF',
-    }),
-    overwrite: true,
-  });
-  files.push({
-    path: path.join(bffDir, 'bff.test.ts'),
-    content: await renderTemplate(path.join(bffTemplateDir, 'bff.test.ts.ejs'), {
-      ...vars,
-      bffClassName: vars.className + 'BFF',
-    }),
-    overwrite: true,
-  });
+  if (manifest.data) {
+    // BFF stub files — only when manifest declares a data: section
+    files.push({
+      path: path.join(bffDir, 'bff.ts'),
+      content: await renderTemplate(path.join(bffTemplateDir, 'bff.ts.ejs'), {
+        ...vars,
+        bffClassName: vars.className + 'BFF',
+      }),
+      overwrite: true,
+    });
+    files.push({
+      path: path.join(bffDir, 'bff.test.ts'),
+      content: await renderTemplate(path.join(bffTemplateDir, 'bff.test.ts.ejs'), {
+        ...vars,
+        bffClassName: vars.className + 'BFF',
+      }),
+      overwrite: true,
+    });
 
-  // BFF main server and root files.
-  //
-  // Important: `package.json` is intentionally NOT in this list. The MFE root
-  // template at `src/codegen/templates/base-mfe/package.json.ejs` is already a
-  // hybrid that owns BOTH MFE deps (rspack, react, MUI, etc.) AND BFF deps
-  // (mesh, express, helmet, etc.). The BFF template's `package.json.ejs` is a
-  // strict subset (no MUI, no MFE-specific scripts) and previously clobbered
-  // the hybrid one because it ran first with `overwrite: true`, leaving the
-  // generated MFE without MUI deps even though `src/App.tsx` imports them.
-  //
-  // `server.ts` stays `overwrite: true` because it's pure BFF runtime that the
-  // user does not customize. The remaining root files (`tsconfig.json`,
-  // `Dockerfile`, `docker-compose.yaml`, `README.md`) flip to `overwrite: false`
-  // so user customization survives regeneration, matching the same convention
-  // used by other root templates further down (`package.json`, `rspack.config.js`).
-  // Angular-webpack emits its own tsconfig.json (with experimentalDecorators,
-  // angularCompilerOptions, etc.) in the root templates block below. Skip the
-  // BFF tsconfig for that variant so the Angular-specific one wins.
-  const bffTemplates: Array<{ tpl: string; out: string; overwrite: boolean }> = [
-    { tpl: 'server.ts.ejs', out: 'server.ts', overwrite: true },
-    ...(templateVariant !== 'angular-webpack'
-      ? [{ tpl: 'tsconfig.json', out: 'tsconfig.json', overwrite: false }]
-      : []),
-    { tpl: 'Dockerfile.ejs', out: 'Dockerfile', overwrite: false },
-    { tpl: 'docker-compose.yaml.ejs', out: 'docker-compose.yaml', overwrite: false },
-    { tpl: 'README.md.ejs', out: 'README.md', overwrite: false },
-  ];
-  // BFF port = MFE port + 1000 (e.g., 3002 → 4002, following e2e2 pattern)
-  const mfePort = vars.port || 3000;
-  const bffPort = mfePort + 1000;
-  const includeStatic = true;
-  for (const { tpl, out, overwrite } of bffTemplates) {
-    const templatePath = path.join(bffTemplateDir, tpl);
-    if (await fs.pathExists(templatePath)) {
-      const content = await renderTemplate(templatePath, { ...vars, port: bffPort, includeStatic, hasData: !!manifest.data });
-      files.push({
-        path: path.join(basePath, out),
-        content,
-        overwrite,
-      });
+    // BFF main server and root files.
+    //
+    // Important: `package.json` is intentionally NOT in this list. The MFE root
+    // template at `src/codegen/templates/base-mfe/package.json.ejs` is already a
+    // hybrid that owns BOTH MFE deps (rspack, react, MUI, etc.) AND BFF deps
+    // (mesh, express, helmet, etc.). The BFF template's `package.json.ejs` is a
+    // strict subset (no MUI, no MFE-specific scripts) and previously clobbered
+    // the hybrid one because it ran first with `overwrite: true`, leaving the
+    // generated MFE without MUI deps even though `src/App.tsx` imports them.
+    //
+    // `server.ts` stays `overwrite: true` because it's pure BFF runtime that the
+    // user does not customize. The remaining root files (`tsconfig.json`,
+    // `Dockerfile`, `docker-compose.yaml`, `README.md`) flip to `overwrite: false`
+    // so user customization survives regeneration, matching the same convention
+    // used by other root templates further down (`package.json`, `rspack.config.js`).
+    // Angular-webpack emits its own tsconfig.json (with experimentalDecorators,
+    // angularCompilerOptions, etc.) in the root templates block below. Skip the
+    // BFF tsconfig for that variant so the Angular-specific one wins.
+    const bffTemplates: Array<{ tpl: string; out: string; overwrite: boolean }> = [
+      { tpl: 'server.ts.ejs', out: 'server.ts', overwrite: true },
+      ...(templateVariant !== 'angular-webpack'
+        ? [{ tpl: 'tsconfig.json', out: 'tsconfig.json', overwrite: false }]
+        : []),
+      { tpl: 'Dockerfile.ejs', out: 'Dockerfile', overwrite: false },
+      { tpl: 'docker-compose.yaml.ejs', out: 'docker-compose.yaml', overwrite: false },
+      { tpl: 'README.md.ejs', out: 'README.md', overwrite: false },
+    ];
+    // BFF port = MFE port + 1000 (e.g., 3002 → 4002, following e2e2 pattern)
+    const mfePort = vars.port || 3000;
+    const bffPort = mfePort + 1000;
+    const includeStatic = true;
+    for (const { tpl, out, overwrite } of bffTemplates) {
+      const templatePath = path.join(bffTemplateDir, tpl);
+      if (await fs.pathExists(templatePath)) {
+        const content = await renderTemplate(templatePath, { ...vars, port: bffPort, includeStatic, hasData: true });
+        files.push({
+          path: path.join(basePath, out),
+          content,
+          overwrite,
+        });
+      }
     }
   }
 

--- a/src/runtime/__tests__/angular-remote-mfe.test.ts
+++ b/src/runtime/__tests__/angular-remote-mfe.test.ts
@@ -124,7 +124,11 @@ describe('AngularRemoteMFE', () => {
       expect(result.container).toBeDefined();
       // Real extractAvailableComponents picks up the domain capability.
       expect(result.availableComponents).toEqual(['Greeter']);
-      expect(result.capabilities).toEqual(expect.arrayContaining(['load', 'render', 'Greeter']));
+      expect(result.capabilities).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'load', type: 'platform' }),
+        expect.objectContaining({ name: 'render', type: 'platform' }),
+        expect.objectContaining({ name: 'Greeter', type: 'domain' }),
+      ]));
       expect((result.telemetry as any).entry).toBeDefined();
       expect((result.telemetry as any).mount).toBeDefined();
       expect((result.telemetry as any).enableRender).toBeDefined();

--- a/src/runtime/__tests__/remote-mfe.integration.test.ts
+++ b/src/runtime/__tests__/remote-mfe.integration.test.ts
@@ -630,4 +630,74 @@ describe('RemoteMFE Integration Tests', () => {
       expect(duration).toBeLessThan(50);
     });
   });
+
+  describe('REQ-RUNTIME-003: LoadResult validation & metadata (issue #50)', () => {
+    it('returns manifest in LoadResult so shell can validate before render', async () => {
+      const mfe = createTestMFE({ App: createReactComponent('App') });
+      const result = await mfe.load({ requestId: 'req-rt003-a', timestamp: new Date() });
+
+      expect(result.status).toBe('loaded');
+      expect(result.manifest).toBeDefined();
+      expect(result.manifest!.name).toBe('test-dashboard-mfe');
+      expect(result.manifest!.version).toBe('1.0.0');
+    });
+
+    it('returns availableComponents so shell can validate component exists before render', async () => {
+      const mfe = createTestMFE({
+        Widget: createReactComponent('Widget'),
+        Chart: createReactComponent('Chart'),
+      });
+      const result = await mfe.load({ requestId: 'req-rt003-b', timestamp: new Date() });
+
+      expect(result.availableComponents).toEqual(expect.arrayContaining(['Widget', 'Chart']));
+    });
+
+    it('returns capabilities metadata so shell can check supported operations', async () => {
+      const mfe = createTestMFE({ App: createReactComponent('App') });
+      const result = await mfe.load({ requestId: 'req-rt003-c', timestamp: new Date() });
+
+      expect(Array.isArray(result.capabilities)).toBe(true);
+      expect(result.capabilities!.length).toBeGreaterThan(0);
+
+      const cap = result.capabilities![0];
+      expect(typeof cap.name).toBe('string');
+      expect(cap.type === 'platform' || cap.type === 'domain').toBe(true);
+    });
+
+    it('returns telemetry with timing for all 3 subphases', async () => {
+      const mfe = createTestMFE({ App: createReactComponent('App') });
+      const result = await mfe.load({ requestId: 'req-rt003-d', timestamp: new Date() });
+
+      expect(result.telemetry).toBeDefined();
+      expect(result.telemetry!.entry.start).toBeInstanceOf(Date);
+      expect(typeof result.telemetry!.entry.duration).toBe('number');
+      expect(result.telemetry!.mount.start).toBeInstanceOf(Date);
+      expect(typeof result.telemetry!.mount.duration).toBe('number');
+      expect(result.telemetry!.enableRender.start).toBeInstanceOf(Date);
+      expect(typeof result.telemetry!.enableRender.duration).toBe('number');
+    });
+
+    it('returns duration in LoadResult', async () => {
+      const mfe = createTestMFE({ App: createReactComponent('App') });
+      const result = await mfe.load({ requestId: 'req-rt003-e', timestamp: new Date() });
+
+      expect(typeof result.duration).toBe('number');
+      expect(result.duration).toBeGreaterThanOrEqual(0);
+    });
+
+    it('returns structured error shape on load failure', async () => {
+      const mfe = createTestMFE({});
+      // Force fetchContainer to fail
+      (mfe as any).fetchContainer = async () => { throw new Error('network timeout'); };
+
+      const result = await mfe.load({ requestId: 'req-rt003-f', timestamp: new Date() });
+
+      expect(result.status).toBe('error');
+      expect(result.error).toBeDefined();
+      expect(typeof result.error!.message).toBe('string');
+      expect(typeof result.error!.phase).toBe('string');
+      expect(typeof result.error!.retryCount).toBe('number');
+      expect(typeof result.error!.retryable).toBe('boolean');
+    });
+  });
 });

--- a/src/runtime/angular-remote-mfe.ts
+++ b/src/runtime/angular-remote-mfe.ts
@@ -26,6 +26,7 @@ import {
   QueryResult,
   EmitResult,
   ControlPlaneStateResult,
+  type CapabilityMetadata,
 } from './base-mfe';
 import type { Message, ActionRecord, MessageMetadata } from './contracts';
 import type { ModuleFederationContainer } from './remote-mfe';
@@ -237,11 +238,17 @@ export class AngularRemoteMFE extends BaseMFE {
         });
       }
 
+      const err = error as Error;
       return {
         status: 'error',
         timestamp: new Date(),
         duration: Date.now() - startTime,
-        error: error as Error,
+        error: {
+          message: err.message ?? String(err),
+          phase: 'entry',
+          retryCount: 0,
+          retryable: true,
+        },
         telemetry,
       };
     }
@@ -498,19 +505,25 @@ export class AngularRemoteMFE extends BaseMFE {
   }
 
   /**
-   * Extract capability metadata from manifest
+   * Extract capability metadata from manifest (REQ-RUNTIME-003)
    */
-  private extractCapabilities(): string[] {
+  private extractCapabilities(): CapabilityMetadata[] {
     if (!this.manifest.capabilities) {
       return [];
     }
 
-    const capabilityNames: string[] = [];
+    const result: CapabilityMetadata[] = [];
     for (const capEntry of this.manifest.capabilities) {
-      const keys = Object.keys(capEntry);
-      capabilityNames.push(...keys);
+      for (const [name, def] of Object.entries(capEntry)) {
+        const d = def as { type?: string; description?: string } | undefined;
+        result.push({
+          name,
+          type: d?.type === 'domain' ? 'domain' : 'platform',
+          description: d?.description,
+        });
+      }
     }
-    return capabilityNames;
+    return result;
   }
 
   /**
@@ -648,7 +661,7 @@ export class AngularRemoteMFE extends BaseMFE {
       name: this.manifest.name,
       version: this.manifest.version,
       type: this.manifest.type,
-      capabilities: this.extractCapabilities(),
+      capabilities: this.extractCapabilities().map((c) => c.name),
       manifest: this.manifest,
     };
   }

--- a/src/runtime/base-mfe.ts
+++ b/src/runtime/base-mfe.ts
@@ -67,14 +67,30 @@ export interface BaseMFEDependencies {
 
 type Worker = any;
 
+/** Metadata for a single capability declared in the manifest */
+export interface CapabilityMetadata {
+  name: string;
+  type: 'platform' | 'domain';
+  description?: string;
+}
+
 /** Result from load capability */
 export interface LoadResult {
   status: 'loaded' | 'error';
-  container?: unknown;  // Module Federation container
-  mesh?: unknown;       // GraphQL Mesh instance
-  worker?: Worker;      // Web Worker instance
+  container?: unknown;
+  mesh?: unknown;
+  worker?: Worker;
+  manifest?: import('../dsl/schema').DSLManifest;
+  availableComponents?: string[];
+  capabilities?: CapabilityMetadata[];
   timestamp: Date;
-  [key: string]: unknown;
+  duration?: number;
+  telemetry?: {
+    entry: { start: Date; duration: number };
+    mount: { start: Date; duration: number };
+    enableRender: { start: Date; duration: number };
+  };
+  error?: { message: string; phase: string; retryCount: number; retryable: boolean };
 }
 
 /** Result from render capability */

--- a/src/runtime/remote-mfe.ts
+++ b/src/runtime/remote-mfe.ts
@@ -21,6 +21,7 @@ import {
   QueryResult,
   EmitResult,
   ControlPlaneStateResult,
+  type CapabilityMetadata,
 } from './base-mfe';
 import type { DSLManifest } from '../dsl/schema';
 import type { Message, ActionRecord, MessageMetadata } from './contracts';
@@ -232,11 +233,17 @@ export class RemoteMFE extends BaseMFE {
         });
       }
 
+      const err = error as Error;
       return {
         status: 'error',
         timestamp: new Date(),
         duration: Date.now() - startTime,
-        error: error as Error,
+        error: {
+          message: err.message ?? String(err),
+          phase: 'entry',
+          retryCount: 0,
+          retryable: true,
+        },
         telemetry,
       };
     }
@@ -503,20 +510,25 @@ export class RemoteMFE extends BaseMFE {
   }
 
   /**
-   * Extract capability metadata from manifest
+   * Extract capability metadata from manifest (REQ-RUNTIME-003)
    */
-  private extractCapabilities(): string[] {
+  private extractCapabilities(): CapabilityMetadata[] {
     if (!this.manifest.capabilities) {
       return [];
     }
 
-    // Extract capability names from manifest entries
-    const capabilityNames: string[] = [];
+    const result: CapabilityMetadata[] = [];
     for (const capEntry of this.manifest.capabilities) {
-      const keys = Object.keys(capEntry);
-      capabilityNames.push(...keys);
+      for (const [name, def] of Object.entries(capEntry)) {
+        const d = def as { type?: string; description?: string } | undefined;
+        result.push({
+          name,
+          type: d?.type === 'domain' ? 'domain' : 'platform',
+          description: d?.description,
+        });
+      }
     }
-    return capabilityNames;
+    return result;
   }
 
   /**
@@ -613,7 +625,7 @@ export class RemoteMFE extends BaseMFE {
       name: this.manifest.name,
       version: this.manifest.version,
       type: this.manifest.type,
-      capabilities: this.extractCapabilities(),
+      capabilities: this.extractCapabilities().map((c) => c.name),
       manifest: this.manifest,
     };
   }


### PR DESCRIPTION
## Summary

- **ADR-071 Phase 4** (#181, #185, #182): Open DSL schema, unified `remote:init`, framework plugin authoring guide
- **REQ-RUNTIME-003** (#50): Fully typed `LoadResult` with manifest, capabilities metadata, telemetry subphases, and structured error shape
- **Codegen BFF fixes** (#149, #189): BFF files skipped when no `data:` section; dead `hasData` conditional removed from templates

## Changes by issue

| Issue | What changed |
|---|---|
| #181 | `FrameworkSchema`/`BundlerSchema` → `z.string().min(1)`; `KNOWN_FRAMEWORKS`/`KNOWN_BUNDLERS` constants; stderr warning for unknown values |
| #185 | `remote:init --framework` drops hardcoded `options:[]` list; unknown framework fails at `loadFrameworkPlugin()` with `ValidationError` |
| #182 | `docs/framework-plugin-authoring.md` — full authoring guide with `vue-vite` skeleton; link added to `README.md` |
| #50 | `CapabilityMetadata` interface added; `LoadResult` fully typed (manifest, availableComponents, capabilities, duration, telemetry, structured error); `extractCapabilities()` returns `CapabilityMetadata[]` in both `RemoteMFE` and `AngularRemoteMFE` |
| #149 | BFF files (`bff.ts`, `bff.test.ts`, `server.ts`, Dockerfile, docker-compose, README) skipped when `manifest.data` absent |
| #189 | `<% if (hasData) { %>` removed from `Dockerfile.ejs` and `server.ts.ejs` — always true since #149 fix |

## Verified E2E

Full clean Docker build across all abc-kids MFEs passes. `LoadResult` fields confirmed live from browser console:

```js
const container = window['abc_kids_flappy'];
await container.init({});
const { mfe } = (await container.get('./bootstrap'))();
const result = await mfe.load({ requestId: 'test', timestamp: new Date(),
  inputs: { remoteEntry: 'http://localhost:3001/remoteEntry.js' } });
// result.manifest.name, result.availableComponents, result.capabilities (CapabilityMetadata[]),
// result.telemetry.entry/mount/enableRender, result.duration
```

## Acceptance criteria

- [x] `FrameworkSchema.parse('svelte')` passes without error
- [x] Unknown framework in manifest → warning on stderr, no schema error
- [x] `remote:init --framework vue` → `ValidationError` from loader (not oclif)
- [x] `docs/framework-plugin-authoring.md` exists with vue-vite skeleton
- [x] `LoadResult` has typed `manifest`, `availableComponents`, `capabilities: CapabilityMetadata[]`, `duration`, `telemetry`, `error: { message, phase, retryCount, retryable }`
- [x] BFF files not generated when manifest has no `data:` section
- [x] All tests pass (2 pre-existing failures in cli-workflow + codegen-workflow are unrelated)

## Governing ADRs

- ADR-071 — Framework plugin system
- ADR-060 — Load capability atomic operation design

Closes #181, #185, #182, #50, #149, #189