### PR TITLE
feat(examples): inner-voice MFE — domain functionality + manifest

### DIFF
--- a/.github/workflows/deploy-inner-voice.yml
+++ b/.github/workflows/deploy-inner-voice.yml
@@ -1,0 +1,30 @@
+name: Deploy inner-voice demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/inner-voice/**'
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+        working-directory: examples/inner-voice/demo
+      - run: npm run build
+        working-directory: examples/inner-voice/demo
+        env:
+          VITE_DEMO_MODE: 'true'
+          VITE_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          VITE_BASE_PATH: '/seans-mfe-tool/inner-voice/'
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./examples/inner-voice/demo/dist
+          destination_dir: inner-voice

--- a/examples/inner-voice/README.md
+++ b/examples/inner-voice/README.md
@@ -1,0 +1,172 @@
+# inner-voice
+
+A no-send-button thinking interface, delivered as a domain-capability MFE. You
+think out loud in the left panel; after a beat of silence the local LLM
+(`coder serve`) streams a response into the right panel and the model's concept
+threads radiate from the center. Clicking a thread folds it back into your
+thought and the loop continues. It is the **human input layer for the agentic
+delivery loop**.
+
+This directory is structured as a **manifest-driven drop-in**: the domain
+functionality (`src/`) and the manifest (`mfe-manifest.yaml`) are authored here,
+and the platform scaffold (`src/platform/**`, `rspack.config.js`, `package.json`,
+etc.) is produced by the SMT generator. Regenerate the scaffold, drop the
+manifest + `src/` on top, and you have a running MFE.
+
+---
+
+## What's here vs. what the generator produces
+
+| Authored here (domain functionality + manifest) | Produced by `remote:generate` (platform scaffold) |
+|---|---|
+| `mfe-manifest.yaml` | `src/platform/base-mfe/{mfe,bootstrap,types}.ts` |
+| `src/features/InnerVoice/*` (the capability component) | `src/remote.tsx`, `src/App.tsx`, `src/index.tsx` |
+| `src/hooks/*`, `src/lib/*` | `rspack.config.js`, `package.json`, `tsconfig.json` |
+| `tests/*` (pure-logic unit tests) | Docker/nginx, jest config |
+| `demo/*` (standalone Vite demo) + deploy workflow | — |
+
+`demo/` is deliberately a **separate** Vite app so `remote:generate --force`
+(which overwrites the rspack scaffold) never clobbers the GitHub Pages build.
+
+---
+
+## Build it (local, federated)
+
+```bash
+# 1. Start the local inference server (falese/coder)
+coder serve                         # http://localhost:3991  (uses default_model)
+#   or, for a no-model smoke test:
+CODER_DRY_RUN=1 coder serve
+
+# 2. Scaffold the platform code from the manifest (from the seans-mfe-tool root)
+bun bin/dev.ts remote:init inner-voice --port 3009 --framework react
+#    -> then copy this directory's mfe-manifest.yaml + src/ over the scaffold
+bun bin/dev.ts remote:generate       # run inside examples/inner-voice
+
+# 3. Run the MFE dev server
+bun bin/dev.ts build:dev             # serves remoteEntry.js on :3009
+```
+
+Load it in a shell by pointing the shell at
+`http://localhost:3009/remoteEntry.js` and rendering the `InnerVoice` capability,
+exactly as with any other generated remote.
+
+### Two integration edits to the generated `src/platform/base-mfe/mfe.ts`
+
+The generator emits a stub component resolver; point it at the real component
+and inject the manifest `config:` block as props so `describe()`'s config flows
+into the UI (the component also has hardcoded fallbacks, so this is optional):
+
+```ts
+// resolve the domain component
+protected async loadDomainComponent(name: string): Promise<unknown> {
+  if (name === 'InnerVoice') {
+    return import('../../features/InnerVoice/InnerVoice').then(
+      (m) => m.InnerVoice ?? m.default,
+    );
+  }
+  return super.loadDomainComponent(name);
+}
+
+// pass manifest config -> component props
+protected async doRender(context: Context): Promise<RenderResult> {
+  context.inputs = {
+    ...context.inputs,
+    props: { config: this.manifest.config, ...(context.inputs?.props ?? {}) },
+  };
+  return super.doRender(context);
+}
+```
+
+`onLoadError` is declared `contained: true` in the manifest, so a failed load is
+logged via the platform handler and isolated rather than crashing the shell.
+
+---
+
+## Run the demo (standalone, Anthropic API)
+
+The GitHub Pages demo can't reach `coder serve`, so it streams from the
+Anthropic API directly (browser, demo only).
+
+```bash
+cd examples/inner-voice/demo
+npm install
+VITE_DEMO_MODE=true VITE_ANTHROPIC_API_KEY=sk-ant-... npm run dev
+```
+
+Pushing to `main` (touching `examples/inner-voice/**`) runs
+`.github/workflows/deploy-inner-voice.yml`, which builds `demo/` with
+`VITE_DEMO_MODE=true` and publishes to GitHub Pages at:
+
+> https://falese.github.io/seans-mfe-tool/inner-voice/
+
+The repo secret `ANTHROPIC_API_KEY` must be set. Demo model defaults to
+`claude-sonnet-4-6` (low latency for an interactive thinking partner); override
+with `VITE_ANTHROPIC_MODEL`.
+
+Without `VITE_DEMO_MODE`, the same component targets `coder serve` at
+`coderServeUrl` (default `http://localhost:3991`).
+
+---
+
+## Configuration
+
+All values come from the manifest `config:` block and have hardcoded fallbacks
+in `src/lib/config.ts`, so the MFE runs with no manifest:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `coderServeUrl` | `http://localhost:3991` | local SSE inference endpoint |
+| `pauseMs` | `2200` | silence before a response triggers |
+| `minChars` | `12` | minimum thought length to trigger |
+| `maxHistoryTurns` | `6` | prior responses retained (faded) |
+| `maxThreads` | `12` | unique session threads retained |
+
+---
+
+## Tests
+
+The runtime-agnostic core (thread parsing, SSE parsing, radial layout, config
+resolution, thread accumulation) is unit-tested and runs without React:
+
+```bash
+cd examples/inner-voice
+bun test tests/      # 23 tests
+```
+
+Component/hook behavior is exercised once the platform scaffold is generated
+(jest, via `remote:generate`).
+
+---
+
+## Layout
+
+```
+mfe-manifest.yaml                     # capabilities + config + lifecycle
+src/
+  features/InnerVoice/
+    InnerVoice.tsx                    # root: layout, CSS, wires hooks
+    ThoughtPanel.tsx                  # left: textarea + countdown bar
+    ThreadWeb.tsx                     # center: pulse + radial nodes
+    ThreadNode.tsx                    # one radial concept node
+    PulseRing.tsx                     # center pulse + rings
+    ResponsePanel.tsx                 # right: streaming text + thread history
+    index.ts
+  hooks/
+    usePauseTimer.ts                  # debounced silence trigger
+    useCoderStream.ts                 # streaming state machine
+    useThreads.ts                     # thread accumulation
+  lib/
+    streamCoder.ts                    # coder serve SSE client
+    streamClaude.ts                   # Anthropic API SSE client (demo)
+    runStream.ts                      # backend dispatch (local vs demo)
+    sse.ts                            # incremental SSE parser
+    parseThreads.ts                   # <threads> extraction + strip
+    threads.ts                        # dedupe/cap accumulation
+    threadLayout.ts                   # radial trigonometry
+    config.ts                         # config resolution + defaults
+    systemPrompt.ts                   # shared system prompt
+    env.ts                            # Vite env accessors
+tests/                               # bun unit tests for lib/
+demo/                                # standalone Vite app for GitHub Pages
+```

--- a/examples/inner-voice/README.md
+++ b/examples/inner-voice/README.md
@@ -122,6 +122,13 @@ in `src/lib/config.ts`, so the MFE runs with no manifest:
 | `maxHistoryTurns` | `6` | prior responses retained (faded) |
 | `maxThreads` | `12` | unique session threads retained |
 | `maxTokens` | `1024` | token budget per generation (headroom for reasoning models) |
+| `systemPrompt` | built-in | the persona/instructions sent every request — override to retune behavior |
+
+The persona lives in `src/lib/systemPrompt.ts` (`SYSTEM_PROMPT`) and is the single
+source of every behavioral constraint (length, "thinking partner" framing, the
+`<threads>` block). Override it per-deployment via the manifest `systemPrompt`
+config — but **keep the `<threads>{...}</threads>` instruction**, or the center
+thread web stops populating.
 
 ### Dual-voice (reasoning models)
 

--- a/examples/inner-voice/README.md
+++ b/examples/inner-voice/README.md
@@ -121,6 +121,18 @@ in `src/lib/config.ts`, so the MFE runs with no manifest:
 | `minChars` | `12` | minimum thought length to trigger |
 | `maxHistoryTurns` | `6` | prior responses retained (faded) |
 | `maxThreads` | `12` | unique session threads retained |
+| `maxTokens` | `1024` | token budget per generation (headroom for reasoning models) |
+
+### Dual-voice (reasoning models)
+
+`coder serve` is channel-aware: it splits a model's reasoning from its answer and
+tags each streamed token `thought` or `final`. The UI renders the **thought**
+channel as a second inner voice (italic, accent-tinted, indented) braided above
+the crystallized **final** answer — so a reasoning model's thinking becomes part
+of the experience rather than noise. Threads are pulled from the final answer,
+falling back to the reasoning. Instruct models (no reasoning) are unaffected —
+everything is `final`. Supported reasoning formats: DeepSeek `<think>…</think>`
+and Harmony `<|channel|>analysis/final`.
 
 ---
 

--- a/examples/inner-voice/demo/index.html
+++ b/examples/inner-voice/demo/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>inner-voice</title>
+    <style>
+      html, body, #root { height: 100%; margin: 0; background: #040404; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/inner-voice/demo/package.json
+++ b/examples/inner-voice/demo/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "inner-voice-demo",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.7.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/examples/inner-voice/demo/src/main.tsx
+++ b/examples/inner-voice/demo/src/main.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { InnerVoice } from "../../src/features/InnerVoice/InnerVoice";
+
+// Standalone demo harness. In demo mode (VITE_DEMO_MODE=true) the component
+// streams from the Anthropic API; otherwise it targets a local `coder serve`.
+const el = document.getElementById("root");
+if (el) {
+  createRoot(el).render(
+    <React.StrictMode>
+      <InnerVoice />
+    </React.StrictMode>,
+  );
+}

--- a/examples/inner-voice/demo/tsconfig.json
+++ b/examples/inner-voice/demo/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["vite/client", "react", "react-dom"]
+  },
+  "include": ["src", "../src"]
+}

--- a/examples/inner-voice/demo/vite.config.ts
+++ b/examples/inner-voice/demo/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// base is set at build time from VITE_BASE_PATH (GitHub Pages serves under a
+// subpath, e.g. /seans-mfe-tool/inner-voice/). Defaults to "/" for local dev.
+export default defineConfig({
+  base: process.env.VITE_BASE_PATH ?? "/",
+  plugins: [react()],
+  build: { outDir: "dist" },
+});

--- a/examples/inner-voice/mfe-manifest.yaml
+++ b/examples/inner-voice/mfe-manifest.yaml
@@ -1,0 +1,46 @@
+name: inner-voice
+version: 1.0.0
+type: remote
+language: typescript
+framework: react
+bundler: rspack
+description: >
+  No-send-button thinking interface. Streams tokens from the local MLX
+  inference server (coder serve) as the user thinks out loud, extracts concept
+  threads in real time, and feeds them back as the input layer for the agentic
+  delivery loop.
+
+endpoint: http://localhost:3009
+remoteEntry: http://localhost:3009/remoteEntry.js
+discovery: http://localhost:3009/.well-known/mfe-manifest.yaml
+
+capabilities:
+  - InnerVoice:
+      type: domain
+      description: >
+        No-send-button thinking interface. Streams tokens from the local
+        MLX inference server as the user types. Extracts concept threads
+        in real time. Input layer for the agentic delivery loop.
+
+  - Load:
+      type: platform
+      lifecycle:
+        error:
+          - onLoadError:
+              handler: onLoadError
+              contained: true
+
+# Domain configuration. Every value also has a hardcoded fallback in the
+# component, so the MFE runs standalone without a manifest. The platform
+# exposes this block at runtime via describe()/doDescribe().
+config:
+  coderServeUrl: http://localhost:3991
+  pauseMs: 2200
+  minChars: 12
+  maxHistoryTurns: 6
+  maxThreads: 12
+
+dependencies:
+  runtime:
+    react: ^18.0.0
+    react-dom: ^18.0.0

--- a/examples/inner-voice/mfe-manifest.yaml
+++ b/examples/inner-voice/mfe-manifest.yaml
@@ -39,6 +39,7 @@ config:
   minChars: 12
   maxHistoryTurns: 6
   maxThreads: 12
+  maxTokens: 1024
 
 dependencies:
   runtime:

--- a/examples/inner-voice/mfe-manifest.yaml
+++ b/examples/inner-voice/mfe-manifest.yaml
@@ -40,6 +40,11 @@ config:
   maxHistoryTurns: 6
   maxThreads: 12
   maxTokens: 1024
+  # systemPrompt overrides the built-in persona. Keep the <threads>{...}</threads>
+  # instruction or the center thread web stops populating. Example:
+  # systemPrompt: |
+  #   You are a terse research assistant. Answer with facts, no hedging.
+  #   Always end with <threads>{"threads":["..."]}</threads> (max 4).
 
 dependencies:
   runtime:

--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -124,13 +124,28 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
 
   const glow = pause.active || stream.isStreaming;
 
+  // Below the firing threshold: surface "n / minChars" so the silent gate reads
+  // as "keep typing", not "broken".
+  const trimmedLen = thought.trim().length;
+  const minHint =
+    !stream.isStreaming && trimmedLen > 0 && trimmedLen < cfg.minChars
+      ? `${String(trimmedLen)} / ${String(cfg.minChars)}`
+      : null;
+  const status = stream.isStreaming
+    ? "streaming…"
+    : pause.active
+      ? "listening…"
+      : minHint
+        ? `keep typing… ${minHint}`
+        : "idle";
+
   return (
     <div className="iv-root">
       <style dangerouslySetInnerHTML={{ __html: CSS }} />
 
       <header style={headerStyle}>
         <span>inner-voice</span>
-        <span>{stream.isStreaming ? "streaming…" : pause.active ? "listening…" : "idle"}</span>
+        <span>{status}</span>
       </header>
 
       <main style={gridStyle}>
@@ -142,6 +157,7 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
             countdownActive={pause.active}
             restartKey={pause.restartKey}
             pauseMs={cfg.pauseMs}
+            minHint={minHint}
           />
         </section>
 

--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -90,7 +90,12 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
     [cfg.maxHistoryTurns, threads],
   );
 
-  const stream = useCoderStream({ coderServeUrl: cfg.coderServeUrl, maxTokens: cfg.maxTokens, onComplete });
+  const stream = useCoderStream({
+    coderServeUrl: cfg.coderServeUrl,
+    maxTokens: cfg.maxTokens,
+    systemPrompt: cfg.systemPrompt,
+    onComplete,
+  });
 
   const pause = usePauseTimer({
     text: thought,

--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useState } from "react";
+import { ThoughtPanel } from "./ThoughtPanel";
+import { ThreadWeb } from "./ThreadWeb";
+import { ResponsePanel } from "./ResponsePanel";
+import { usePauseTimer } from "../../hooks/usePauseTimer";
+import { useCoderStream, type StreamMetrics } from "../../hooks/useCoderStream";
+import { useThreads } from "../../hooks/useThreads";
+import { resolveConfig, type InnerVoiceConfig } from "../../lib/config";
+import { parseThreads, stripThreads } from "../../lib/parseThreads";
+
+export interface InnerVoiceProps {
+  /** Manifest config block (from describe()/doDescribe()). Falls back to defaults. */
+  config?: Partial<Record<keyof InnerVoiceConfig, unknown>>;
+}
+
+const CSS = `
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital@0;1&family=JetBrains+Mono&display=swap');
+.iv-root {
+  --bg:#040404; --surface:#0d0d0d; --border:#141414;
+  --text:#c8c8c8; --muted:#2a2a2a; --accent:#00ff9f;
+  background:var(--bg); color:var(--text);
+  height:100vh; display:flex; flex-direction:column; overflow:hidden;
+}
+.iv-root, .iv-root *, .iv-root *::before, .iv-root *::after { box-sizing:border-box; }
+.iv-root ::placeholder { color:var(--muted); }
+.iv-root ::-webkit-scrollbar { width:6px; height:6px; }
+.iv-root ::-webkit-scrollbar-thumb { background:var(--border); border-radius:3px; }
+@keyframes countdownBar { from { width:0%; } to { width:100%; } }
+@keyframes pulseRing { from { transform:scale(1); opacity:0.6; } to { transform:scale(2.5); opacity:0; } }
+@keyframes fadeUp { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:translateY(0); } }
+@keyframes blink { 50% { opacity:0; } }
+@keyframes threadIn { from { opacity:0; transform:scale(0.6); } to { opacity:1; transform:scale(1); } }
+`;
+
+const headerStyle: React.CSSProperties = {
+  flex: "0 0 auto",
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "10px 16px",
+  borderBottom: "1px solid var(--border)",
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: 11,
+  color: "var(--muted)",
+};
+const footerStyle: React.CSSProperties = {
+  flex: "0 0 auto",
+  padding: "8px 16px",
+  borderTop: "1px solid var(--border)",
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: 10,
+  color: "var(--muted)",
+  textAlign: "center",
+};
+const gridStyle: React.CSSProperties = {
+  flex: 1,
+  minHeight: 0,
+  display: "grid",
+  gridTemplateColumns: "1fr 200px 1fr",
+  gap: 0,
+};
+const colStyle: React.CSSProperties = {
+  minHeight: 0,
+  minWidth: 0,
+  padding: "12px 16px",
+  borderRight: "1px solid var(--border)",
+  display: "flex",
+};
+
+export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
+  const cfg = resolveConfig(config);
+  const [thought, setThought] = useState("");
+  const [turns, setTurns] = useState<string[]>([]);
+
+  const threads = useThreads(cfg.maxThreads);
+
+  const onComplete = useCallback(
+    (full: string, _metrics: StreamMetrics) => {
+      const display = stripThreads(full);
+      if (display.length > 0) {
+        setTurns((t) => [...t, display].slice(-cfg.maxHistoryTurns));
+      }
+      threads.setFromResponse(parseThreads(full));
+    },
+    [cfg.maxHistoryTurns, threads],
+  );
+
+  const stream = useCoderStream({ coderServeUrl: cfg.coderServeUrl, onComplete });
+
+  const pause = usePauseTimer({
+    text: thought,
+    pauseMs: cfg.pauseMs,
+    minChars: cfg.minChars,
+    enabled: !stream.isStreaming,
+    onFire: () => {
+      if (thought.trim().length >= cfg.minChars) stream.start(thought);
+    },
+  });
+
+  const followThread = useCallback((concept: string) => {
+    setThought((t) => `${t.trimEnd()}${t.trim() ? " " : ""}[following thread: ${concept}]`);
+  }, []);
+
+  const handleEscape = useCallback(() => {
+    setThought("");
+    stream.reset();
+    threads.clearCurrent();
+    // session thread history persists by design
+  }, [stream, threads]);
+
+  const glow = pause.active || stream.isStreaming;
+
+  return (
+    <div className="iv-root">
+      <style dangerouslySetInnerHTML={{ __html: CSS }} />
+
+      <header style={headerStyle}>
+        <span>inner-voice</span>
+        <span>{stream.isStreaming ? "streaming…" : pause.active ? "listening…" : "idle"}</span>
+      </header>
+
+      <main style={gridStyle}>
+        <section style={colStyle}>
+          <ThoughtPanel
+            value={thought}
+            onChange={setThought}
+            onEscape={handleEscape}
+            countdownActive={pause.active}
+            restartKey={pause.restartKey}
+            pauseMs={cfg.pauseMs}
+          />
+        </section>
+
+        <section style={{ ...colStyle, padding: 0 }}>
+          <ThreadWeb
+            threads={threads.current}
+            active={glow}
+            streaming={stream.isStreaming}
+            onThreadClick={followThread}
+          />
+        </section>
+
+        <section style={{ ...colStyle, borderRight: "none" }}>
+          <ResponsePanel
+            turns={turns}
+            liveText={stream.isStreaming ? stream.display : null}
+            isStreaming={stream.isStreaming}
+            error={stream.error}
+            metrics={stream.metrics}
+            history={threads.history}
+            onThreadClick={followThread}
+          />
+        </section>
+      </main>
+
+      <footer style={footerStyle}>
+        no send button — responds after {String(cfg.pauseMs)}ms of silence · esc to clear
+      </footer>
+    </div>
+  );
+};
+
+export default InnerVoice;

--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -56,7 +56,7 @@ const gridStyle: React.CSSProperties = {
   flex: 1,
   minHeight: 0,
   display: "grid",
-  gridTemplateColumns: "1fr 200px 1fr",
+  gridTemplateColumns: "1fr 340px 1fr",
   gap: 0,
 };
 const colStyle: React.CSSProperties = {

--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { ThoughtPanel } from "./ThoughtPanel";
 import { ThreadWeb } from "./ThreadWeb";
 import { ResponsePanel } from "./ResponsePanel";
@@ -71,21 +71,26 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
   const cfg = resolveConfig(config);
   const [thought, setThought] = useState("");
   const [turns, setTurns] = useState<string[]>([]);
+  // The thought last sent to the model — guards against re-sending identical text
+  // (the whole evolving thought IS the prompt; we just never repeat it verbatim).
+  const lastSent = useRef("");
 
   const threads = useThreads(cfg.maxThreads);
 
   const onComplete = useCallback(
-    (full: string, _metrics: StreamMetrics) => {
-      const display = stripThreads(full);
+    (final: string, thought_: string, _metrics: StreamMetrics) => {
+      const display = stripThreads(final);
       if (display.length > 0) {
         setTurns((t) => [...t, display].slice(-cfg.maxHistoryTurns));
       }
-      threads.setFromResponse(parseThreads(full));
+      // Prefer threads from the final answer; fall back to the reasoning voice.
+      const found = parseThreads(final);
+      threads.setFromResponse(found.length > 0 ? found : parseThreads(thought_));
     },
     [cfg.maxHistoryTurns, threads],
   );
 
-  const stream = useCoderStream({ coderServeUrl: cfg.coderServeUrl, onComplete });
+  const stream = useCoderStream({ coderServeUrl: cfg.coderServeUrl, maxTokens: cfg.maxTokens, onComplete });
 
   const pause = usePauseTimer({
     text: thought,
@@ -93,7 +98,10 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
     minChars: cfg.minChars,
     enabled: !stream.isStreaming,
     onFire: () => {
-      if (thought.trim().length >= cfg.minChars) stream.start(thought);
+      if (thought.trim().length >= cfg.minChars && thought !== lastSent.current) {
+        lastSent.current = thought;
+        stream.start(thought);
+      }
     },
   });
 
@@ -103,6 +111,7 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
 
   const handleEscape = useCallback(() => {
     setThought("");
+    lastSent.current = "";
     stream.reset();
     threads.clearCurrent();
     // session thread history persists by design
@@ -144,6 +153,7 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
           <ResponsePanel
             turns={turns}
             liveText={stream.isStreaming ? stream.display : null}
+            thinking={stream.thinking}
             isStreaming={stream.isStreaming}
             error={stream.error}
             metrics={stream.metrics}

--- a/examples/inner-voice/src/features/InnerVoice/PulseRing.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/PulseRing.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+export interface PulseRingProps {
+  /** Glow the dot during countdown or streaming. */
+  active: boolean;
+  /** Animate the radiating rings during an active stream. */
+  streaming: boolean;
+}
+
+const base: React.CSSProperties = {
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  width: 10,
+  height: 10,
+  marginLeft: -5,
+  marginTop: -5,
+  borderRadius: "50%",
+};
+
+export const PulseRing: React.FC<PulseRingProps> = ({ active, streaming }) => {
+  const dot: React.CSSProperties = {
+    ...base,
+    zIndex: 2,
+    background: active ? "var(--accent)" : "var(--muted)",
+    boxShadow: active ? "0 0 14px var(--accent)" : "none",
+    transition: "background 0.3s ease, box-shadow 0.3s ease",
+  };
+  const ring = (delay: string): React.CSSProperties => ({
+    ...base,
+    zIndex: 1,
+    border: "1px solid var(--accent)",
+    animation: `pulseRing 1.5s ease-out ${delay} infinite`,
+  });
+  return (
+    <>
+      {streaming ? <span style={ring("0s")} /> : null}
+      {streaming ? <span style={ring("0.5s")} /> : null}
+      <span style={dot} />
+    </>
+  );
+};
+
+export default PulseRing;

--- a/examples/inner-voice/src/features/InnerVoice/ResponsePanel.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ResponsePanel.tsx
@@ -4,8 +4,10 @@ import type { StreamMetrics } from "../../hooks/useCoderStream";
 export interface ResponsePanelProps {
   /** Completed responses, oldest first. */
   turns: string[];
-  /** Live streaming text, or null when idle. */
+  /** Live streaming final answer, or null when idle. */
   liveText: string | null;
+  /** The model's reasoning ("inner voice") for the current/last turn — empty for non-reasoning models. */
+  thinking: string;
   isStreaming: boolean;
   error: string | null;
   metrics: StreamMetrics | null;
@@ -18,6 +20,7 @@ export interface ResponsePanelProps {
 export const ResponsePanel: React.FC<ResponsePanelProps> = ({
   turns,
   liveText,
+  thinking,
   isStreaming,
   error,
   metrics,
@@ -26,6 +29,8 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
 }) => {
   const priors = isStreaming ? turns : turns.slice(0, -1);
   const active = isStreaming ? liveText ?? "" : turns.length > 0 ? turns[turns.length - 1] : null;
+  // Cursor lives on the thinking voice until the final answer starts forming.
+  const cursorOnThinking = isStreaming && thinking.length > 0 && (active === null || active === "");
 
   const wrap: React.CSSProperties = {
     display: "flex",
@@ -70,6 +75,33 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
     padding: "2px 6px",
     cursor: "pointer",
   };
+  // The model's reasoning rendered as a second inner voice — italic, accent-tinted,
+  // indented behind a thin rule, dimmer than the crystallized answer.
+  const innerVoice: React.CSSProperties = {
+    fontFamily: "'EB Garamond', serif",
+    fontStyle: "italic",
+    fontSize: 15,
+    lineHeight: 1.7,
+    color: "var(--accent)",
+    opacity: 0.55,
+    borderLeft: "2px solid var(--accent)",
+    paddingLeft: 12,
+    margin: "0 0 12px",
+    whiteSpace: "pre-wrap",
+  };
+  const cursor = (
+    <span
+      style={{
+        display: "inline-block",
+        width: 7,
+        marginLeft: 1,
+        color: "var(--accent)",
+        animation: "blink 0.6s step-end infinite",
+      }}
+    >
+      ▋
+    </span>
+  );
 
   return (
     <div style={wrap}>
@@ -87,22 +119,17 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
           <p style={{ ...meta, color: "var(--accent)" }}>⚠ {error}</p>
         ) : null}
 
-        {active !== null ? (
+        {thinking.length > 0 ? (
+          <div style={innerVoice} aria-label="model inner voice">
+            {thinking}
+            {cursorOnThinking ? cursor : null}
+          </div>
+        ) : null}
+
+        {active !== null && active !== "" ? (
           <p key={`active-${String(turns.length)}`} style={{ margin: "0 0 8px", animation: "fadeUp 0.3s ease" }}>
             {active}
-            {isStreaming ? (
-              <span
-                style={{
-                  display: "inline-block",
-                  width: 7,
-                  marginLeft: 1,
-                  color: "var(--accent)",
-                  animation: "blink 0.6s step-end infinite",
-                }}
-              >
-                ▋
-              </span>
-            ) : null}
+            {isStreaming && !cursorOnThinking ? cursor : null}
           </p>
         ) : null}
 

--- a/examples/inner-voice/src/features/InnerVoice/ResponsePanel.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ResponsePanel.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import type { StreamMetrics } from "../../hooks/useCoderStream";
+
+export interface ResponsePanelProps {
+  /** Completed responses, oldest first. */
+  turns: string[];
+  /** Live streaming text, or null when idle. */
+  liveText: string | null;
+  isStreaming: boolean;
+  error: string | null;
+  metrics: StreamMetrics | null;
+  /** Accumulated unique session threads. */
+  history: string[];
+  onThreadClick: (thread: string) => void;
+}
+
+/** Right panel: streaming response, faded prior turns, and session thread history. */
+export const ResponsePanel: React.FC<ResponsePanelProps> = ({
+  turns,
+  liveText,
+  isStreaming,
+  error,
+  metrics,
+  history,
+  onThreadClick,
+}) => {
+  const priors = isStreaming ? turns : turns.slice(0, -1);
+  const active = isStreaming ? liveText ?? "" : turns.length > 0 ? turns[turns.length - 1] : null;
+
+  const wrap: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    minHeight: 0,
+  };
+  const scroll: React.CSSProperties = {
+    flex: 1,
+    minHeight: 0,
+    overflowY: "auto",
+    fontFamily: "'EB Garamond', serif",
+    fontSize: 17,
+    lineHeight: 1.8,
+    color: "var(--text)",
+    padding: "8px 4px",
+  };
+  const meta: React.CSSProperties = {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: 10,
+    color: "var(--muted)",
+    marginTop: 6,
+  };
+  const historyBox: React.CSSProperties = {
+    flex: "0 0 auto",
+    borderTop: "1px solid var(--border)",
+    paddingTop: 8,
+    marginTop: 8,
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 6,
+    maxHeight: 120,
+    overflowY: "auto",
+  };
+  const chip: React.CSSProperties = {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: 10,
+    color: "var(--text)",
+    background: "var(--surface)",
+    border: "1px solid var(--border)",
+    borderRadius: 3,
+    padding: "2px 6px",
+    cursor: "pointer",
+  };
+
+  return (
+    <div style={wrap}>
+      <div style={scroll}>
+        {priors.map((text, i) => (
+          <p
+            key={`prior-${String(i)}`}
+            style={{ opacity: 0.15 + (i / Math.max(priors.length, 1)) * 0.2, margin: "0 0 14px" }}
+          >
+            {text}
+          </p>
+        ))}
+
+        {error ? (
+          <p style={{ ...meta, color: "var(--accent)" }}>⚠ {error}</p>
+        ) : null}
+
+        {active !== null ? (
+          <p key={`active-${String(turns.length)}`} style={{ margin: "0 0 8px", animation: "fadeUp 0.3s ease" }}>
+            {active}
+            {isStreaming ? (
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 7,
+                  marginLeft: 1,
+                  color: "var(--accent)",
+                  animation: "blink 0.6s step-end infinite",
+                }}
+              >
+                ▋
+              </span>
+            ) : null}
+          </p>
+        ) : null}
+
+        {metrics && !isStreaming ? (
+          <div style={meta}>
+            ttft {String(Math.round(metrics.ttft))}ms · {metrics.tokensPerSec.toFixed(1)} tok/s
+          </div>
+        ) : null}
+      </div>
+
+      {history.length > 0 ? (
+        <div style={historyBox} aria-label="thread history">
+          {history.map((thread, i) => (
+            <button
+              type="button"
+              key={`hist-${thread}-${String(i)}`}
+              style={chip}
+              onClick={() => onThreadClick(thread)}
+              title={thread}
+            >
+              {thread}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ResponsePanel;

--- a/examples/inner-voice/src/features/InnerVoice/ThoughtPanel.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThoughtPanel.tsx
@@ -8,6 +8,8 @@ export interface ThoughtPanelProps {
   /** Restarts the countdown bar animation on each keystroke. */
   restartKey: number;
   pauseMs: number;
+  /** Shown while the thought is below the firing threshold, e.g. "4 / 12". Null otherwise. */
+  minHint: string | null;
 }
 
 /** Left panel: the borderless thought field plus the silence countdown bar. */
@@ -18,6 +20,7 @@ export const ThoughtPanel: React.FC<ThoughtPanelProps> = ({
   countdownActive,
   restartKey,
   pauseMs,
+  minHint,
 }) => {
   const wrap: React.CSSProperties = {
     display: "flex",
@@ -50,6 +53,13 @@ export const ThoughtPanel: React.FC<ThoughtPanelProps> = ({
     lineHeight: 1.8,
     padding: "8px 4px",
   };
+  const hint: React.CSSProperties = {
+    flex: "0 0 auto",
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: 10,
+    color: "var(--muted)",
+    padding: "0 4px 4px",
+  };
   return (
     <div style={wrap}>
       <div style={track}>
@@ -69,6 +79,7 @@ export const ThoughtPanel: React.FC<ThoughtPanelProps> = ({
           }
         }}
       />
+      {minHint ? <div style={hint}>keep typing… {minHint}</div> : null}
     </div>
   );
 };

--- a/examples/inner-voice/src/features/InnerVoice/ThoughtPanel.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThoughtPanel.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+export interface ThoughtPanelProps {
+  value: string;
+  onChange: (value: string) => void;
+  onEscape: () => void;
+  countdownActive: boolean;
+  /** Restarts the countdown bar animation on each keystroke. */
+  restartKey: number;
+  pauseMs: number;
+}
+
+/** Left panel: the borderless thought field plus the silence countdown bar. */
+export const ThoughtPanel: React.FC<ThoughtPanelProps> = ({
+  value,
+  onChange,
+  onEscape,
+  countdownActive,
+  restartKey,
+  pauseMs,
+}) => {
+  const wrap: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    minHeight: 0,
+  };
+  const track: React.CSSProperties = {
+    height: 2,
+    background: "var(--border)",
+    flex: "0 0 auto",
+  };
+  const fill: React.CSSProperties = {
+    height: "100%",
+    width: 0,
+    background: "var(--accent)",
+    animation: `countdownBar ${String(pauseMs)}ms linear forwards`,
+  };
+  const textarea: React.CSSProperties = {
+    flex: 1,
+    minHeight: 0,
+    width: "100%",
+    resize: "none",
+    border: "none",
+    outline: "none",
+    background: "transparent",
+    color: "var(--text)",
+    fontFamily: "'EB Garamond', serif",
+    fontSize: 17,
+    lineHeight: 1.8,
+    padding: "8px 4px",
+  };
+  return (
+    <div style={wrap}>
+      <div style={track}>
+        {countdownActive ? <div key={restartKey} style={fill} /> : null}
+      </div>
+      <textarea
+        style={textarea}
+        value={value}
+        placeholder="start thinking…"
+        autoFocus
+        spellCheck={false}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onEscape();
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+export default ThoughtPanel;

--- a/examples/inner-voice/src/features/InnerVoice/ThreadNode.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThreadNode.tsx
@@ -28,12 +28,11 @@ export const ThreadNode: React.FC<ThreadNodeProps> = ({ label, x, y, index, onCl
     background: "var(--surface)",
     border: "1px solid var(--border)",
     borderRadius: 3,
-    padding: "3px 7px",
+    padding: "4px 8px",
     cursor: "pointer",
-    whiteSpace: "nowrap",
-    maxWidth: 130,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
+    whiteSpace: "normal",
+    textAlign: "center",
+    maxWidth: 104,
     animation: `threadIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) ${String(index * 0.08)}s both`,
   };
   return (

--- a/examples/inner-voice/src/features/InnerVoice/ThreadNode.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThreadNode.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+export interface ThreadNodeProps {
+  label: string;
+  x: number;
+  y: number;
+  index: number;
+  onClick: () => void;
+}
+
+/**
+ * A single radial concept node. The outer wrapper handles absolute positioning
+ * (and centring on its point); the inner button runs the entrance animation, so
+ * the scale/fade never fights the positioning transform.
+ */
+export const ThreadNode: React.FC<ThreadNodeProps> = ({ label, x, y, index, onClick }) => {
+  const wrapper: React.CSSProperties = {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    transform: `translate(calc(-50% + ${String(x)}px), calc(-50% + ${String(y)}px))`,
+  };
+  const button: React.CSSProperties = {
+    fontFamily: "'JetBrains Mono', monospace",
+    fontSize: 10,
+    lineHeight: 1.4,
+    color: "var(--text)",
+    background: "var(--surface)",
+    border: "1px solid var(--border)",
+    borderRadius: 3,
+    padding: "3px 7px",
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+    maxWidth: 130,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    animation: `threadIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) ${String(index * 0.08)}s both`,
+  };
+  return (
+    <div style={wrapper}>
+      <button type="button" style={button} onClick={onClick} title={label}>
+        {label}
+      </button>
+    </div>
+  );
+};
+
+export default ThreadNode;

--- a/examples/inner-voice/src/features/InnerVoice/ThreadWeb.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThreadWeb.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { PulseRing } from "./PulseRing";
+import { ThreadNode } from "./ThreadNode";
+import { threadPosition } from "../../lib/threadLayout";
+
+export interface ThreadWebProps {
+  threads: string[];
+  active: boolean;
+  streaming: boolean;
+  onThreadClick: (thread: string) => void;
+}
+
+/** Center panel: a fixed pulse with concept nodes radiating around it. */
+export const ThreadWeb: React.FC<ThreadWebProps> = ({ threads, active, streaming, onThreadClick }) => {
+  const container: React.CSSProperties = {
+    position: "relative",
+    height: "100%",
+    width: "100%",
+    overflow: "visible",
+  };
+  return (
+    <div style={container} aria-label="thread web">
+      <PulseRing active={active} streaming={streaming} />
+      {threads.map((thread, i) => {
+        const { x, y } = threadPosition(i, threads.length);
+        return (
+          <ThreadNode
+            key={`${thread}-${String(i)}`}
+            label={thread}
+            x={x}
+            y={y}
+            index={i}
+            onClick={() => onThreadClick(thread)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ThreadWeb;

--- a/examples/inner-voice/src/features/InnerVoice/ThreadWeb.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThreadWeb.tsx
@@ -10,6 +10,12 @@ export interface ThreadWebProps {
   onThreadClick: (thread: string) => void;
 }
 
+// threadPosition gives the radial *direction*; these spread the nodes out for
+// legibility — mostly vertically, so same-side concepts land on distinct rows
+// instead of stacking on top of each other in the narrow centre column.
+const SPREAD_X = 1.1;
+const SPREAD_Y = 3.6;
+
 /** Center panel: a fixed pulse with concept nodes radiating around it. */
 export const ThreadWeb: React.FC<ThreadWebProps> = ({ threads, active, streaming, onThreadClick }) => {
   const container: React.CSSProperties = {
@@ -27,8 +33,8 @@ export const ThreadWeb: React.FC<ThreadWebProps> = ({ threads, active, streaming
           <ThreadNode
             key={`${thread}-${String(i)}`}
             label={thread}
-            x={x}
-            y={y}
+            x={x * SPREAD_X}
+            y={y * SPREAD_Y}
             index={i}
             onClick={() => onThreadClick(thread)}
           />

--- a/examples/inner-voice/src/features/InnerVoice/index.ts
+++ b/examples/inner-voice/src/features/InnerVoice/index.ts
@@ -1,0 +1,2 @@
+export { InnerVoice, default } from "./InnerVoice";
+export type { InnerVoiceProps } from "./InnerVoice";

--- a/examples/inner-voice/src/hooks/useCoderStream.ts
+++ b/examples/inner-voice/src/hooks/useCoderStream.ts
@@ -10,6 +10,7 @@ export interface StreamMetrics {
 export interface UseCoderStreamArgs {
   coderServeUrl: string;
   maxTokens: number;
+  systemPrompt: string;
   /** Called with the full RAW final + thought text (threads tags intact) when a stream ends. */
   onComplete?: (final: string, thought: string, metrics: StreamMetrics) => void;
 }
@@ -32,7 +33,7 @@ export interface UseCoderStreamResult {
  * streaming state, timing metrics, and any error. Aborts in-flight requests on
  * a new start, on reset, and on unmount.
  */
-export function useCoderStream({ coderServeUrl, maxTokens, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
+export function useCoderStream({ coderServeUrl, maxTokens, systemPrompt, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
   const [display, setDisplay] = useState("");
   const [thinking, setThinking] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -57,6 +58,7 @@ export function useCoderStream({ coderServeUrl, maxTokens, onComplete }: UseCode
         prompt,
         coderServeUrl,
         maxTokens,
+        system: systemPrompt,
         signal: ac.signal,
         onChunk: (final, thought) => {
           setDisplay(stripThreads(final));
@@ -75,7 +77,7 @@ export function useCoderStream({ coderServeUrl, maxTokens, onComplete }: UseCode
         },
       });
     },
-    [coderServeUrl, maxTokens],
+    [coderServeUrl, maxTokens, systemPrompt],
   );
 
   const reset = useCallback(() => {

--- a/examples/inner-voice/src/hooks/useCoderStream.ts
+++ b/examples/inner-voice/src/hooks/useCoderStream.ts
@@ -9,13 +9,16 @@ export interface StreamMetrics {
 
 export interface UseCoderStreamArgs {
   coderServeUrl: string;
-  /** Called with the full RAW response (threads tag intact) when a stream ends. */
-  onComplete?: (full: string, metrics: StreamMetrics) => void;
+  maxTokens: number;
+  /** Called with the full RAW final + thought text (threads tags intact) when a stream ends. */
+  onComplete?: (final: string, thought: string, metrics: StreamMetrics) => void;
 }
 
 export interface UseCoderStreamResult {
-  /** Live display text (threads tag stripped), accumulates during the stream. */
+  /** Live final answer (threads tag stripped), accumulates during the stream. */
   display: string;
+  /** Live reasoning / "inner voice" of the model (empty for non-reasoning models). */
+  thinking: string;
   isStreaming: boolean;
   error: string | null;
   metrics: StreamMetrics | null;
@@ -29,8 +32,9 @@ export interface UseCoderStreamResult {
  * streaming state, timing metrics, and any error. Aborts in-flight requests on
  * a new start, on reset, and on unmount.
  */
-export function useCoderStream({ coderServeUrl, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
+export function useCoderStream({ coderServeUrl, maxTokens, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
   const [display, setDisplay] = useState("");
+  const [thinking, setThinking] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<StreamMetrics | null>(null);
@@ -45,19 +49,25 @@ export function useCoderStream({ coderServeUrl, onComplete }: UseCoderStreamArgs
       abortRef.current = ac;
       setError(null);
       setDisplay("");
+      setThinking("");
       setMetrics(null);
       setIsStreaming(true);
 
       void runStream({
         prompt,
         coderServeUrl,
+        maxTokens,
         signal: ac.signal,
-        onChunk: (accumulated) => setDisplay(stripThreads(accumulated)),
-        onDone: (full, ttft, tokensPerSec) => {
-          setDisplay(stripThreads(full));
+        onChunk: (final, thought) => {
+          setDisplay(stripThreads(final));
+          setThinking(stripThreads(thought));
+        },
+        onDone: (final, thought, ttft, tokensPerSec) => {
+          setDisplay(stripThreads(final));
+          setThinking(stripThreads(thought));
           setMetrics({ ttft, tokensPerSec });
           setIsStreaming(false);
-          onCompleteRef.current?.(full, { ttft, tokensPerSec });
+          onCompleteRef.current?.(final, thought, { ttft, tokensPerSec });
         },
         onError: (message) => {
           setIsStreaming(false);
@@ -65,12 +75,13 @@ export function useCoderStream({ coderServeUrl, onComplete }: UseCoderStreamArgs
         },
       });
     },
-    [coderServeUrl],
+    [coderServeUrl, maxTokens],
   );
 
   const reset = useCallback(() => {
     abortRef.current?.abort();
     setDisplay("");
+    setThinking("");
     setError(null);
     setMetrics(null);
     setIsStreaming(false);
@@ -78,5 +89,5 @@ export function useCoderStream({ coderServeUrl, onComplete }: UseCoderStreamArgs
 
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  return { display, isStreaming, error, metrics, start, reset };
+  return { display, thinking, isStreaming, error, metrics, start, reset };
 }

--- a/examples/inner-voice/src/hooks/useCoderStream.ts
+++ b/examples/inner-voice/src/hooks/useCoderStream.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { runStream } from "../lib/runStream";
+import { stripThreads } from "../lib/parseThreads";
+
+export interface StreamMetrics {
+  ttft: number;
+  tokensPerSec: number;
+}
+
+export interface UseCoderStreamArgs {
+  coderServeUrl: string;
+  /** Called with the full RAW response (threads tag intact) when a stream ends. */
+  onComplete?: (full: string, metrics: StreamMetrics) => void;
+}
+
+export interface UseCoderStreamResult {
+  /** Live display text (threads tag stripped), accumulates during the stream. */
+  display: string;
+  isStreaming: boolean;
+  error: string | null;
+  metrics: StreamMetrics | null;
+  start: (prompt: string) => void;
+  reset: () => void;
+}
+
+/**
+ * Drives a single generation against the active backend (local `coder serve` or
+ * the Anthropic demo API — chosen inside runStream). Exposes live display text,
+ * streaming state, timing metrics, and any error. Aborts in-flight requests on
+ * a new start, on reset, and on unmount.
+ */
+export function useCoderStream({ coderServeUrl, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
+  const [display, setDisplay] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [metrics, setMetrics] = useState<StreamMetrics | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  const start = useCallback(
+    (prompt: string) => {
+      abortRef.current?.abort();
+      const ac = new AbortController();
+      abortRef.current = ac;
+      setError(null);
+      setDisplay("");
+      setMetrics(null);
+      setIsStreaming(true);
+
+      void runStream({
+        prompt,
+        coderServeUrl,
+        signal: ac.signal,
+        onChunk: (accumulated) => setDisplay(stripThreads(accumulated)),
+        onDone: (full, ttft, tokensPerSec) => {
+          setDisplay(stripThreads(full));
+          setMetrics({ ttft, tokensPerSec });
+          setIsStreaming(false);
+          onCompleteRef.current?.(full, { ttft, tokensPerSec });
+        },
+        onError: (message) => {
+          setIsStreaming(false);
+          setError(message);
+        },
+      });
+    },
+    [coderServeUrl],
+  );
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    setDisplay("");
+    setError(null);
+    setMetrics(null);
+    setIsStreaming(false);
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return { display, isStreaming, error, metrics, start, reset };
+}

--- a/examples/inner-voice/src/hooks/usePauseTimer.ts
+++ b/examples/inner-voice/src/hooks/usePauseTimer.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface UsePauseTimerArgs {
+  text: string;
+  pauseMs: number;
+  minChars: number;
+  /** False while a stream is in progress — the timer never fires then. */
+  enabled: boolean;
+  onFire: () => void;
+}
+
+export interface UsePauseTimerResult {
+  /** True while a countdown is scheduled — drives the pulse glow. */
+  active: boolean;
+  /** Increments on each keystroke; use as the countdown bar's React key to restart its animation. */
+  restartKey: number;
+}
+
+/**
+ * Debounced "silence" trigger. Each change to `text` (re)starts a single timer;
+ * after `pauseMs` of no further changes — and only if `text` has at least
+ * `minChars` and a stream isn't running — `onFire` is called. Toggling `enabled`
+ * does NOT restart the timer, so a finished stream never auto-refires; the next
+ * keystroke does.
+ */
+export function usePauseTimer({
+  text,
+  pauseMs,
+  minChars,
+  enabled,
+  onFire,
+}: UsePauseTimerArgs): UsePauseTimerResult {
+  const [restartKey, setRestartKey] = useState(0);
+  const [active, setActive] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const enabledRef = useRef(enabled);
+  const onFireRef = useRef(onFire);
+  enabledRef.current = enabled;
+  onFireRef.current = onFire;
+
+  useEffect(() => {
+    if (timer.current) clearTimeout(timer.current);
+    if (text.trim().length < minChars || !enabledRef.current) {
+      setActive(false);
+      return;
+    }
+    setActive(true);
+    setRestartKey((k) => k + 1);
+    timer.current = setTimeout(() => {
+      setActive(false);
+      if (enabledRef.current) onFireRef.current();
+    }, pauseMs);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+    // enabled is intentionally read via ref, not a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, pauseMs, minChars]);
+
+  return { active, restartKey };
+}

--- a/examples/inner-voice/src/hooks/useThreads.ts
+++ b/examples/inner-voice/src/hooks/useThreads.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from "react";
+import { accumulateThreads } from "../lib/threads";
+
+export interface UseThreadsResult {
+  /** Threads from the most recent response (the radial nodes). */
+  current: string[];
+  /** All unique threads across the session, capped to maxThreads. */
+  history: string[];
+  setFromResponse: (threads: string[]) => void;
+  clearCurrent: () => void;
+}
+
+/**
+ * Thread state for a session: the current radial set plus an accumulating,
+ * deduped history. Escape clears `current` but leaves `history` intact.
+ */
+export function useThreads(maxThreads: number): UseThreadsResult {
+  const [current, setCurrent] = useState<string[]>([]);
+  const [history, setHistory] = useState<string[]>([]);
+
+  const setFromResponse = useCallback(
+    (threads: string[]) => {
+      setCurrent(threads);
+      setHistory((h) => accumulateThreads(h, threads, maxThreads));
+    },
+    [maxThreads],
+  );
+
+  const clearCurrent = useCallback(() => setCurrent([]), []);
+
+  return { current, history, setFromResponse, clearCurrent };
+}

--- a/examples/inner-voice/src/lib/config.ts
+++ b/examples/inner-voice/src/lib/config.ts
@@ -1,0 +1,51 @@
+/**
+ * Inner-voice runtime configuration.
+ *
+ * Every field has a hardcoded fallback so the MFE runs standalone with no
+ * manifest. At runtime the platform exposes the manifest `config:` block via
+ * describe()/doDescribe(); `resolveConfig` merges any partial source over the
+ * defaults, ignoring values of the wrong type.
+ */
+export interface InnerVoiceConfig {
+  coderServeUrl: string;
+  pauseMs: number;
+  minChars: number;
+  maxHistoryTurns: number;
+  maxThreads: number;
+}
+
+export const DEFAULT_CONFIG: InnerVoiceConfig = {
+  coderServeUrl: "http://localhost:3991",
+  pauseMs: 2200,
+  minChars: 12,
+  maxHistoryTurns: 6,
+  maxThreads: 12,
+};
+
+function num(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function str(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() !== "" ? value : fallback;
+}
+
+/**
+ * Merge a partial config (from the manifest, props, or env) over the defaults.
+ * Never throws; unknown or mistyped fields fall back to the default.
+ */
+export function resolveConfig(source?: Partial<Record<keyof InnerVoiceConfig, unknown>> | null): InnerVoiceConfig {
+  const s = source ?? {};
+  return {
+    coderServeUrl: str(s.coderServeUrl, DEFAULT_CONFIG.coderServeUrl),
+    pauseMs: num(s.pauseMs, DEFAULT_CONFIG.pauseMs),
+    minChars: num(s.minChars, DEFAULT_CONFIG.minChars),
+    maxHistoryTurns: num(s.maxHistoryTurns, DEFAULT_CONFIG.maxHistoryTurns),
+    maxThreads: num(s.maxThreads, DEFAULT_CONFIG.maxThreads),
+  };
+}

--- a/examples/inner-voice/src/lib/config.ts
+++ b/examples/inner-voice/src/lib/config.ts
@@ -12,6 +12,8 @@ export interface InnerVoiceConfig {
   minChars: number;
   maxHistoryTurns: number;
   maxThreads: number;
+  /** Token budget per generation. Reasoning models need headroom for thought + answer. */
+  maxTokens: number;
 }
 
 export const DEFAULT_CONFIG: InnerVoiceConfig = {
@@ -20,6 +22,7 @@ export const DEFAULT_CONFIG: InnerVoiceConfig = {
   minChars: 12,
   maxHistoryTurns: 6,
   maxThreads: 12,
+  maxTokens: 1024,
 };
 
 function num(value: unknown, fallback: number): number {
@@ -47,5 +50,6 @@ export function resolveConfig(source?: Partial<Record<keyof InnerVoiceConfig, un
     minChars: num(s.minChars, DEFAULT_CONFIG.minChars),
     maxHistoryTurns: num(s.maxHistoryTurns, DEFAULT_CONFIG.maxHistoryTurns),
     maxThreads: num(s.maxThreads, DEFAULT_CONFIG.maxThreads),
+    maxTokens: num(s.maxTokens, DEFAULT_CONFIG.maxTokens),
   };
 }

--- a/examples/inner-voice/src/lib/config.ts
+++ b/examples/inner-voice/src/lib/config.ts
@@ -6,6 +6,8 @@
  * describe()/doDescribe(); `resolveConfig` merges any partial source over the
  * defaults, ignoring values of the wrong type.
  */
+import { SYSTEM_PROMPT } from "./systemPrompt";
+
 export interface InnerVoiceConfig {
   coderServeUrl: string;
   pauseMs: number;
@@ -14,6 +16,8 @@ export interface InnerVoiceConfig {
   maxThreads: number;
   /** Token budget per generation. Reasoning models need headroom for thought + answer. */
   maxTokens: number;
+  /** The persona/instructions sent with every request. Override to retune behavior. */
+  systemPrompt: string;
 }
 
 export const DEFAULT_CONFIG: InnerVoiceConfig = {
@@ -23,6 +27,7 @@ export const DEFAULT_CONFIG: InnerVoiceConfig = {
   maxHistoryTurns: 6,
   maxThreads: 12,
   maxTokens: 1024,
+  systemPrompt: SYSTEM_PROMPT,
 };
 
 function num(value: unknown, fallback: number): number {
@@ -51,5 +56,6 @@ export function resolveConfig(source?: Partial<Record<keyof InnerVoiceConfig, un
     maxHistoryTurns: num(s.maxHistoryTurns, DEFAULT_CONFIG.maxHistoryTurns),
     maxThreads: num(s.maxThreads, DEFAULT_CONFIG.maxThreads),
     maxTokens: num(s.maxTokens, DEFAULT_CONFIG.maxTokens),
+    systemPrompt: str(s.systemPrompt, DEFAULT_CONFIG.systemPrompt),
   };
 }

--- a/examples/inner-voice/src/lib/env.ts
+++ b/examples/inner-voice/src/lib/env.ts
@@ -1,0 +1,29 @@
+/**
+ * Safe accessors for Vite build-time env. These read `import.meta.env`, which
+ * only exists under a Vite build; everything is guarded so the module also
+ * imports cleanly under a plain test runner.
+ */
+function readEnv(key: string): string | undefined {
+  try {
+    const env = (import.meta as unknown as { env?: Record<string, string | undefined> }).env;
+    return env?.[key];
+  } catch {
+    return undefined;
+  }
+}
+
+export function isDemoMode(): boolean {
+  return readEnv("VITE_DEMO_MODE") === "true";
+}
+
+export function anthropicApiKey(): string {
+  return readEnv("VITE_ANTHROPIC_API_KEY") ?? "";
+}
+
+export function anthropicModel(): string | undefined {
+  return readEnv("VITE_ANTHROPIC_MODEL");
+}
+
+export function basePath(): string {
+  return readEnv("VITE_BASE_PATH") ?? "/";
+}

--- a/examples/inner-voice/src/lib/parseThreads.ts
+++ b/examples/inner-voice/src/lib/parseThreads.ts
@@ -1,0 +1,39 @@
+/**
+ * Concept-thread extraction.
+ *
+ * The model ends each response with a tag:
+ *   <threads>{"threads":["concept one","concept two"]}</threads>
+ *
+ * `parseThreads` pulls the string array out of that tag; `stripThreads` removes
+ * the tag so the prose can be rendered on its own. Both are total functions —
+ * they never throw and degrade to an empty array / the original-minus-tag.
+ */
+
+const THREADS_TAG = /<threads>\s*([\s\S]*?)\s*<\/threads>/i;
+const THREADS_TAG_GLOBAL = /<threads>[\s\S]*?<\/threads>/gi;
+
+export function parseThreads(raw: string): string[] {
+  const match = THREADS_TAG.exec(raw);
+  if (!match) return [];
+  try {
+    const parsed = JSON.parse(match[1]) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "threads" in parsed &&
+      Array.isArray((parsed as { threads: unknown }).threads)
+    ) {
+      return (parsed as { threads: unknown[] }).threads
+        .filter((t): t is string => typeof t === "string" && t.trim() !== "")
+        .map((t) => t.trim());
+    }
+  } catch {
+    // malformed JSON — fall through to empty array
+  }
+  return [];
+}
+
+/** Return the response text with any <threads>…</threads> block removed. */
+export function stripThreads(raw: string): string {
+  return raw.replace(THREADS_TAG_GLOBAL, "").trimEnd();
+}

--- a/examples/inner-voice/src/lib/runStream.ts
+++ b/examples/inner-voice/src/lib/runStream.ts
@@ -1,0 +1,40 @@
+import type { StreamHandlers } from "./streamCoder";
+import { streamCoder } from "./streamCoder";
+import { streamClaude } from "./streamClaude";
+import { isDemoMode, anthropicApiKey, anthropicModel } from "./env";
+
+export interface RunStreamOptions extends StreamHandlers {
+  prompt: string;
+  coderServeUrl: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Single entry point the UI calls to start a generation. Routes to the Anthropic
+ * API in demo mode (GitHub Pages, no local server) or to a local `coder serve`
+ * SSE endpoint otherwise. Backend choice is invisible to the caller.
+ */
+export function runStream(opts: RunStreamOptions): Promise<void> {
+  const handlers: StreamHandlers = {
+    onChunk: opts.onChunk,
+    onDone: opts.onDone,
+    onError: opts.onError,
+  };
+
+  if (isDemoMode()) {
+    return streamClaude({
+      ...handlers,
+      apiKey: anthropicApiKey(),
+      model: anthropicModel(),
+      prompt: opts.prompt,
+      signal: opts.signal,
+    });
+  }
+
+  return streamCoder({
+    ...handlers,
+    url: opts.coderServeUrl,
+    prompt: opts.prompt,
+    signal: opts.signal,
+  });
+}

--- a/examples/inner-voice/src/lib/runStream.ts
+++ b/examples/inner-voice/src/lib/runStream.ts
@@ -7,6 +7,7 @@ export interface RunStreamOptions extends StreamHandlers {
   prompt: string;
   coderServeUrl: string;
   maxTokens?: number;
+  system?: string;
   signal?: AbortSignal;
 }
 
@@ -29,6 +30,7 @@ export function runStream(opts: RunStreamOptions): Promise<void> {
       model: anthropicModel(),
       prompt: opts.prompt,
       maxTokens: opts.maxTokens,
+      system: opts.system,
       signal: opts.signal,
     });
   }
@@ -38,6 +40,7 @@ export function runStream(opts: RunStreamOptions): Promise<void> {
     url: opts.coderServeUrl,
     prompt: opts.prompt,
     maxTokens: opts.maxTokens,
+    system: opts.system,
     signal: opts.signal,
   });
 }

--- a/examples/inner-voice/src/lib/runStream.ts
+++ b/examples/inner-voice/src/lib/runStream.ts
@@ -6,6 +6,7 @@ import { isDemoMode, anthropicApiKey, anthropicModel } from "./env";
 export interface RunStreamOptions extends StreamHandlers {
   prompt: string;
   coderServeUrl: string;
+  maxTokens?: number;
   signal?: AbortSignal;
 }
 
@@ -27,6 +28,7 @@ export function runStream(opts: RunStreamOptions): Promise<void> {
       apiKey: anthropicApiKey(),
       model: anthropicModel(),
       prompt: opts.prompt,
+      maxTokens: opts.maxTokens,
       signal: opts.signal,
     });
   }
@@ -35,6 +37,7 @@ export function runStream(opts: RunStreamOptions): Promise<void> {
     ...handlers,
     url: opts.coderServeUrl,
     prompt: opts.prompt,
+    maxTokens: opts.maxTokens,
     signal: opts.signal,
   });
 }

--- a/examples/inner-voice/src/lib/sse.ts
+++ b/examples/inner-voice/src/lib/sse.ts
@@ -1,0 +1,68 @@
+/**
+ * Minimal incremental SSE parser for the `coder serve` /generate stream.
+ *
+ * The server emits one JSON object per `data:` line:
+ *   data: {"type":"token","text":"..."}
+ *   data: {"type":"done","ttft":142,"tokensPerSec":23.1,"totalTokens":87}
+ *   data: [DONE]
+ *   data: {"type":"error","message":"..."}
+ *
+ * `SseParser.push` is fed raw decoded chunks (which may split mid-line) and
+ * returns whatever complete events it could parse. It never throws; malformed
+ * payloads are dropped.
+ */
+export type CoderEvent =
+  | { type: "token"; text: string }
+  | { type: "done"; ttft: number; tokensPerSec: number; totalTokens: number }
+  | { type: "error"; message: string }
+  | { type: "sentinel" };
+
+export function parseSseData(payload: string): CoderEvent | null {
+  const data = payload.trim();
+  if (data === "") return null;
+  if (data === "[DONE]") return { type: "sentinel" };
+  try {
+    const obj = JSON.parse(data) as Record<string, unknown>;
+    if (obj.type === "token" && typeof obj.text === "string") {
+      return { type: "token", text: obj.text };
+    }
+    if (obj.type === "done") {
+      return {
+        type: "done",
+        ttft: typeof obj.ttft === "number" ? obj.ttft : 0,
+        tokensPerSec: typeof obj.tokensPerSec === "number" ? obj.tokensPerSec : 0,
+        totalTokens: typeof obj.totalTokens === "number" ? obj.totalTokens : 0,
+      };
+    }
+    if (obj.type === "error") {
+      return {
+        type: "error",
+        message: typeof obj.message === "string" ? obj.message : "unknown error",
+      };
+    }
+  } catch {
+    // malformed JSON — drop
+  }
+  return null;
+}
+
+export class SseParser {
+  private buffer = "";
+
+  push(chunk: string): CoderEvent[] {
+    this.buffer += chunk;
+    const events: CoderEvent[] = [];
+    let newlineIndex = this.buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      const trimmed = line.replace(/\r$/, "");
+      if (trimmed.startsWith("data:")) {
+        const event = parseSseData(trimmed.slice("data:".length));
+        if (event) events.push(event);
+      }
+      newlineIndex = this.buffer.indexOf("\n");
+    }
+    return events;
+  }
+}

--- a/examples/inner-voice/src/lib/sse.ts
+++ b/examples/inner-voice/src/lib/sse.ts
@@ -11,8 +11,10 @@
  * returns whatever complete events it could parse. It never throws; malformed
  * payloads are dropped.
  */
+export type Channel = "thought" | "final";
+
 export type CoderEvent =
-  | { type: "token"; text: string }
+  | { type: "token"; channel: Channel; text: string }
   | { type: "done"; ttft: number; tokensPerSec: number; totalTokens: number }
   | { type: "error"; message: string }
   | { type: "sentinel" };
@@ -24,7 +26,8 @@ export function parseSseData(payload: string): CoderEvent | null {
   try {
     const obj = JSON.parse(data) as Record<string, unknown>;
     if (obj.type === "token" && typeof obj.text === "string") {
-      return { type: "token", text: obj.text };
+      // Older servers omit `channel`; default to "final" for back-compat.
+      return { type: "token", channel: obj.channel === "thought" ? "thought" : "final", text: obj.text };
     }
     if (obj.type === "done") {
       return {

--- a/examples/inner-voice/src/lib/streamClaude.ts
+++ b/examples/inner-voice/src/lib/streamClaude.ts
@@ -1,0 +1,127 @@
+import type { StreamHandlers } from "./streamCoder";
+import { SYSTEM_PROMPT } from "./systemPrompt";
+
+export interface StreamClaudeOptions extends StreamHandlers {
+  apiKey: string;
+  prompt: string;
+  system?: string;
+  maxTokens?: number;
+  model?: string;
+  signal?: AbortSignal;
+}
+
+const ANTHROPIC_URL = "https://api.anthropic.com/v1/messages";
+// Current low-latency model for an interactive thinking partner. The original
+// product spec named claude-sonnet-4-20250514 (now deprecated); claude-sonnet-4-6
+// is the current Sonnet. Override via VITE_ANTHROPIC_MODEL.
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+interface AnthropicDelta {
+  type?: string;
+  text?: string;
+}
+interface AnthropicStreamEvent {
+  type?: string;
+  delta?: AnthropicDelta;
+  usage?: { output_tokens?: number };
+}
+
+/**
+ * Browser demo path: stream a generation directly from the Anthropic Messages
+ * API (SSE). Used on GitHub Pages where `coder serve` isn't reachable. Requires
+ * an API key injected at build time (VITE_ANTHROPIC_API_KEY) — demo only; never
+ * ship a real key to production.
+ *
+ * Failures are reported via onError, never thrown.
+ */
+export async function streamClaude(opts: StreamClaudeOptions): Promise<void> {
+  const { apiKey, prompt, system = SYSTEM_PROMPT, maxTokens = 1024, model = DEFAULT_MODEL, signal } = opts;
+
+  if (!apiKey) {
+    opts.onError(
+      "Demo mode is missing an API key. Set VITE_ANTHROPIC_API_KEY at build time.",
+    );
+    return;
+  }
+
+  const start = Date.now();
+  let response: Response;
+  try {
+    response = await fetch(ANTHROPIC_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        // Required to call the API directly from a browser (demo only).
+        "anthropic-dangerous-direct-browser-access": "true",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxTokens,
+        system,
+        stream: true,
+        messages: [{ role: "user", content: prompt }],
+      }),
+      signal,
+    });
+  } catch (err) {
+    if (signal?.aborted) return;
+    opts.onError(err instanceof Error ? err.message : "network error");
+    return;
+  }
+
+  if (!response.ok || !response.body) {
+    opts.onError(`Anthropic API returned HTTP ${String(response.status)}`);
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let accumulated = "";
+  let ttft = 0;
+  let outputTokens = 0;
+
+  const handleEvent = (event: AnthropicStreamEvent): void => {
+    if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
+      if (ttft === 0) ttft = Date.now() - start;
+      accumulated += event.delta.text ?? "";
+      opts.onChunk(accumulated);
+    } else if (event.type === "message_delta" && typeof event.usage?.output_tokens === "number") {
+      outputTokens = event.usage.output_tokens;
+    } else if (event.type === "error") {
+      opts.onError("Anthropic API stream error");
+    }
+  };
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let nl = buffer.indexOf("\n");
+      while (nl !== -1) {
+        const line = buffer.slice(0, nl).replace(/\r$/, "");
+        buffer = buffer.slice(nl + 1);
+        if (line.startsWith("data:")) {
+          const payload = line.slice("data:".length).trim();
+          if (payload && payload !== "[DONE]") {
+            try {
+              handleEvent(JSON.parse(payload) as AnthropicStreamEvent);
+            } catch {
+              // ignore non-JSON keepalive lines
+            }
+          }
+        }
+        nl = buffer.indexOf("\n");
+      }
+    }
+    const elapsedSec = (Date.now() - start) / 1000;
+    const tokensPerSec = elapsedSec > 0 ? outputTokens / elapsedSec : 0;
+    opts.onDone(accumulated, ttft, tokensPerSec);
+  } catch (err) {
+    if (signal?.aborted) return;
+    opts.onError(err instanceof Error ? err.message : "stream error");
+  }
+}

--- a/examples/inner-voice/src/lib/streamClaude.ts
+++ b/examples/inner-voice/src/lib/streamClaude.ts
@@ -87,7 +87,8 @@ export async function streamClaude(opts: StreamClaudeOptions): Promise<void> {
     if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
       if (ttft === 0) ttft = Date.now() - start;
       accumulated += event.delta.text ?? "";
-      opts.onChunk(accumulated);
+      // Demo path has no reasoning channel — everything is the "final" voice.
+      opts.onChunk(accumulated, "");
     } else if (event.type === "message_delta" && typeof event.usage?.output_tokens === "number") {
       outputTokens = event.usage.output_tokens;
     } else if (event.type === "error") {
@@ -119,7 +120,7 @@ export async function streamClaude(opts: StreamClaudeOptions): Promise<void> {
     }
     const elapsedSec = (Date.now() - start) / 1000;
     const tokensPerSec = elapsedSec > 0 ? outputTokens / elapsedSec : 0;
-    opts.onDone(accumulated, ttft, tokensPerSec);
+    opts.onDone(accumulated, "", ttft, tokensPerSec);
   } catch (err) {
     if (signal?.aborted) return;
     opts.onError(err instanceof Error ? err.message : "stream error");

--- a/examples/inner-voice/src/lib/streamCoder.ts
+++ b/examples/inner-voice/src/lib/streamCoder.ts
@@ -1,0 +1,88 @@
+import { SseParser } from "./sse";
+import { SYSTEM_PROMPT } from "./systemPrompt";
+
+export interface StreamHandlers {
+  /** Accumulated raw text so far (still includes any <threads> tag). */
+  onChunk: (text: string) => void;
+  /** Final raw text plus timing metrics. */
+  onDone: (full: string, ttft: number, tokensPerSec: number) => void;
+  /** Human-readable failure message. */
+  onError: (message: string) => void;
+}
+
+export interface StreamCoderOptions extends StreamHandlers {
+  url: string;
+  prompt: string;
+  system?: string;
+  maxTokens?: number;
+  signal?: AbortSignal;
+}
+
+function corsHelp(url: string): string {
+  return (
+    `[inner-voice] Cannot reach coder serve at ${url}. Start it with:\n` +
+    `  coder serve                 (uses default_model from ~/.coder/config.toml)\n` +
+    `  CODER_DRY_RUN=1 coder serve  (for testing without a model)`
+  );
+}
+
+/**
+ * Stream a generation from a local `coder serve` SSE endpoint. Resolves when
+ * the stream ends. All failures (network, CORS, HTTP, abort) are reported via
+ * `onError` rather than thrown, so the UI can degrade gracefully.
+ */
+export async function streamCoder(opts: StreamCoderOptions): Promise<void> {
+  const { url, prompt, system = SYSTEM_PROMPT, maxTokens = 512, signal } = opts;
+  const endpoint = `${url.replace(/\/$/, "")}/generate`;
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt, system, maxTokens }),
+      signal,
+    });
+  } catch (err) {
+    if (signal?.aborted) return;
+    // eslint-disable-next-line no-console
+    console.warn(corsHelp(url));
+    opts.onError(err instanceof Error ? err.message : "network error");
+    return;
+  }
+
+  if (!response.ok || !response.body) {
+    opts.onError(`coder serve returned HTTP ${String(response.status)}`);
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const parser = new SseParser();
+  let accumulated = "";
+  let ttft = 0;
+  let tokensPerSec = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      for (const event of parser.push(decoder.decode(value, { stream: true }))) {
+        if (event.type === "token") {
+          accumulated += event.text;
+          opts.onChunk(accumulated);
+        } else if (event.type === "done") {
+          ttft = event.ttft;
+          tokensPerSec = event.tokensPerSec;
+        } else if (event.type === "error") {
+          opts.onError(event.message);
+          return;
+        }
+      }
+    }
+    opts.onDone(accumulated, ttft, tokensPerSec);
+  } catch (err) {
+    if (signal?.aborted) return;
+    opts.onError(err instanceof Error ? err.message : "stream error");
+  }
+}

--- a/examples/inner-voice/src/lib/streamCoder.ts
+++ b/examples/inner-voice/src/lib/streamCoder.ts
@@ -2,10 +2,10 @@ import { SseParser } from "./sse";
 import { SYSTEM_PROMPT } from "./systemPrompt";
 
 export interface StreamHandlers {
-  /** Accumulated raw text so far (still includes any <threads> tag). */
-  onChunk: (text: string) => void;
-  /** Final raw text plus timing metrics. */
-  onDone: (full: string, ttft: number, tokensPerSec: number) => void;
+  /** Accumulated final + thought text so far (each still includes any <threads> tag). */
+  onChunk: (final: string, thought: string) => void;
+  /** Final + thought text plus timing metrics. */
+  onDone: (final: string, thought: string, ttft: number, tokensPerSec: number) => void;
   /** Human-readable failure message. */
   onError: (message: string) => void;
 }
@@ -59,7 +59,8 @@ export async function streamCoder(opts: StreamCoderOptions): Promise<void> {
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   const parser = new SseParser();
-  let accumulated = "";
+  let final = "";
+  let thought = "";
   let ttft = 0;
   let tokensPerSec = 0;
 
@@ -69,8 +70,9 @@ export async function streamCoder(opts: StreamCoderOptions): Promise<void> {
       if (done) break;
       for (const event of parser.push(decoder.decode(value, { stream: true }))) {
         if (event.type === "token") {
-          accumulated += event.text;
-          opts.onChunk(accumulated);
+          if (event.channel === "thought") thought += event.text;
+          else final += event.text;
+          opts.onChunk(final, thought);
         } else if (event.type === "done") {
           ttft = event.ttft;
           tokensPerSec = event.tokensPerSec;
@@ -80,7 +82,7 @@ export async function streamCoder(opts: StreamCoderOptions): Promise<void> {
         }
       }
     }
-    opts.onDone(accumulated, ttft, tokensPerSec);
+    opts.onDone(final, thought, ttft, tokensPerSec);
   } catch (err) {
     if (signal?.aborted) return;
     opts.onError(err instanceof Error ? err.message : "stream error");

--- a/examples/inner-voice/src/lib/systemPrompt.ts
+++ b/examples/inner-voice/src/lib/systemPrompt.ts
@@ -5,10 +5,12 @@
  */
 export const SYSTEM_PROMPT = `You are a thinking partner for someone who thinks in continuous inner speech.
 
-Respond in 3-6 sentences. Do not summarize. Move the thought forward: surface
-a branch they haven't taken, name a tension, or compress toward the core idea.
+Match what they need: when they ask for facts or a direct answer, give it plainly;
+otherwise move the thought forward — surface a branch they haven't taken, name a
+tension, or compress toward the core idea. Keep it tight (usually 2-6 sentences),
+no preamble.
 
-End your response with concept threads as a JSON block — no other format:
+Always end your response with concept threads as a JSON block — no other format:
 <threads>{"threads":["concept one","concept two","concept three"]}</threads>
 
-Maximum 4 threads. No preamble.`;
+Maximum 4 threads.`;

--- a/examples/inner-voice/src/lib/systemPrompt.ts
+++ b/examples/inner-voice/src/lib/systemPrompt.ts
@@ -1,0 +1,14 @@
+/**
+ * System prompt sent with every request, in both local (coder serve) and demo
+ * (Claude API) modes. Instructs the model to think alongside the user and to
+ * close with a machine-parseable <threads> block (see parseThreads.ts).
+ */
+export const SYSTEM_PROMPT = `You are a thinking partner for someone who thinks in continuous inner speech.
+
+Respond in 3-6 sentences. Do not summarize. Move the thought forward: surface
+a branch they haven't taken, name a tension, or compress toward the core idea.
+
+End your response with concept threads as a JSON block — no other format:
+<threads>{"threads":["concept one","concept two","concept three"]}</threads>
+
+Maximum 4 threads. No preamble.`;

--- a/examples/inner-voice/src/lib/threadLayout.ts
+++ b/examples/inner-voice/src/lib/threadLayout.ts
@@ -1,0 +1,21 @@
+/**
+ * Radial placement for thread nodes around the centre pulse.
+ *
+ * Nodes fan out across a 120° arc (-60°…+60° from straight up), with every
+ * other node pushed out slightly further so they don't overlap. The vertical
+ * axis is squashed (×0.5) to fit the centre panel's aspect.
+ */
+export interface ThreadPosition {
+  x: number;
+  y: number;
+}
+
+export function threadPosition(index: number, total: number): ThreadPosition {
+  const angleDeg = (index / Math.max(total - 1, 1)) * 120 - 60;
+  const angleRad = (angleDeg * Math.PI) / 180;
+  const radius = 90 + (index % 2) * 20;
+  return {
+    x: Math.sin(angleRad) * radius,
+    y: -Math.cos(angleRad) * radius * 0.5,
+  };
+}

--- a/examples/inner-voice/src/lib/threads.ts
+++ b/examples/inner-voice/src/lib/threads.ts
@@ -1,0 +1,19 @@
+/**
+ * Session-wide thread accumulation. Threads surfaced across turns are kept
+ * unique (first-seen order) and capped to `max`, retaining the most recent.
+ */
+export function accumulateThreads(
+  history: readonly string[],
+  incoming: readonly string[],
+  max: number,
+): string[] {
+  const seen = new Set(history);
+  const merged = [...history];
+  for (const thread of incoming) {
+    if (!seen.has(thread)) {
+      seen.add(thread);
+      merged.push(thread);
+    }
+  }
+  return max > 0 && merged.length > max ? merged.slice(merged.length - max) : merged;
+}

--- a/examples/inner-voice/tests/lib.test.ts
+++ b/examples/inner-voice/tests/lib.test.ts
@@ -75,7 +75,10 @@ describe("threadPosition", () => {
 
 describe("SSE parsing", () => {
   test("parseSseData maps token / done / sentinel / error", () => {
-    expect(parseSseData('{"type":"token","text":"hi"}')).toEqual({ type: "token", text: "hi" });
+    expect(parseSseData('{"type":"token","text":"hi"}')).toEqual({ type: "token", channel: "final", text: "hi" });
+    expect(parseSseData('{"type":"token","channel":"thought","text":"hmm"}')).toEqual({
+      type: "token", channel: "thought", text: "hmm",
+    });
     expect(parseSseData('{"type":"done","ttft":1,"tokensPerSec":2,"totalTokens":3}')).toEqual({
       type: "done", ttft: 1, tokensPerSec: 2, totalTokens: 3,
     });
@@ -88,7 +91,7 @@ describe("SSE parsing", () => {
     const p = new SseParser();
     expect(p.push('data: {"type":"to')).toEqual([]);
     const events = p.push('ken","text":"abc"}\n\ndata: [DONE]\n');
-    expect(events[0]).toEqual({ type: "token", text: "abc" });
+    expect(events[0]).toEqual({ type: "token", channel: "final", text: "abc" });
     expect(events[1]).toEqual({ type: "sentinel" });
   });
 

--- a/examples/inner-voice/tests/lib.test.ts
+++ b/examples/inner-voice/tests/lib.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from "bun:test";
+import { resolveConfig, DEFAULT_CONFIG } from "../src/lib/config";
+import { accumulateThreads } from "../src/lib/threads";
+import { threadPosition } from "../src/lib/threadLayout";
+import { SseParser, parseSseData } from "../src/lib/sse";
+
+describe("resolveConfig", () => {
+  test("returns defaults for empty/undefined source", () => {
+    expect(resolveConfig()).toEqual(DEFAULT_CONFIG);
+    expect(resolveConfig(null)).toEqual(DEFAULT_CONFIG);
+  });
+
+  test("overrides with valid manifest values", () => {
+    const c = resolveConfig({ coderServeUrl: "http://x:1", pauseMs: 1000, maxThreads: 5 });
+    expect(c.coderServeUrl).toBe("http://x:1");
+    expect(c.pauseMs).toBe(1000);
+    expect(c.maxThreads).toBe(5);
+    // untouched fields keep defaults
+    expect(c.minChars).toBe(DEFAULT_CONFIG.minChars);
+  });
+
+  test("coerces numeric strings and ignores garbage", () => {
+    const c = resolveConfig({ pauseMs: "1800", minChars: "oops", maxHistoryTurns: {} });
+    expect(c.pauseMs).toBe(1800);
+    expect(c.minChars).toBe(DEFAULT_CONFIG.minChars);
+    expect(c.maxHistoryTurns).toBe(DEFAULT_CONFIG.maxHistoryTurns);
+  });
+});
+
+describe("accumulateThreads", () => {
+  test("appends unique threads preserving first-seen order", () => {
+    expect(accumulateThreads(["a"], ["b", "c"], 12)).toEqual(["a", "b", "c"]);
+  });
+
+  test("dedupes against history and within the incoming batch", () => {
+    expect(accumulateThreads(["a", "b"], ["b", "a", "d"], 12)).toEqual(["a", "b", "d"]);
+  });
+
+  test("caps to max, keeping the most recent", () => {
+    expect(accumulateThreads(["a", "b", "c"], ["d"], 2)).toEqual(["c", "d"]);
+  });
+
+  test("max <= 0 means no cap", () => {
+    expect(accumulateThreads(["a", "b"], ["c"], 0)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("threadPosition", () => {
+  test("index 0 anchors the -60° edge of the arc (x and y negative)", () => {
+    // Per spec: angle = (i / max(total-1,1)) * 120 - 60, so i=0 → -60°.
+    const p = threadPosition(0, 1);
+    expect(p.x).toBeLessThan(0);
+    expect(p.y).toBeLessThan(0);
+  });
+
+  test("first of several leans left, last leans right", () => {
+    const left = threadPosition(0, 3);
+    const right = threadPosition(2, 3);
+    expect(left.x).toBeLessThan(0);
+    expect(right.x).toBeGreaterThan(0);
+  });
+
+  test("middle node of three sits near the top (x≈0)", () => {
+    const mid = threadPosition(1, 3);
+    expect(Math.abs(mid.x)).toBeLessThan(1e-9);
+  });
+
+  test("every-other node is pushed further out", () => {
+    // index 1 uses radius 90+20=110 vs index 0/2 radius 90
+    const p1 = threadPosition(1, 4);
+    expect(Number.isFinite(p1.x)).toBe(true);
+    expect(Number.isFinite(p1.y)).toBe(true);
+  });
+});
+
+describe("SSE parsing", () => {
+  test("parseSseData maps token / done / sentinel / error", () => {
+    expect(parseSseData('{"type":"token","text":"hi"}')).toEqual({ type: "token", text: "hi" });
+    expect(parseSseData('{"type":"done","ttft":1,"tokensPerSec":2,"totalTokens":3}')).toEqual({
+      type: "done", ttft: 1, tokensPerSec: 2, totalTokens: 3,
+    });
+    expect(parseSseData("[DONE]")).toEqual({ type: "sentinel" });
+    expect(parseSseData('{"type":"error","message":"boom"}')).toEqual({ type: "error", message: "boom" });
+    expect(parseSseData("not json")).toBeNull();
+  });
+
+  test("SseParser reassembles events split across chunks", () => {
+    const p = new SseParser();
+    expect(p.push('data: {"type":"to')).toEqual([]);
+    const events = p.push('ken","text":"abc"}\n\ndata: [DONE]\n');
+    expect(events[0]).toEqual({ type: "token", text: "abc" });
+    expect(events[1]).toEqual({ type: "sentinel" });
+  });
+
+  test("SseParser ignores non-data lines", () => {
+    const p = new SseParser();
+    expect(p.push("event: ping\n:keepalive\n")).toEqual([]);
+  });
+});

--- a/examples/inner-voice/tests/parseThreads.test.ts
+++ b/examples/inner-voice/tests/parseThreads.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { parseThreads, stripThreads } from "../src/lib/parseThreads";
+
+describe("parseThreads", () => {
+  test("extracts a thread array from a well-formed tag", () => {
+    const raw = 'Some thought.\n<threads>{"threads":["a","b","c"]}</threads>';
+    expect(parseThreads(raw)).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns [] when no tag is present", () => {
+    expect(parseThreads("just prose, no threads")).toEqual([]);
+  });
+
+  test("returns [] on malformed JSON inside the tag (never throws)", () => {
+    expect(parseThreads("<threads>{not json}</threads>")).toEqual([]);
+  });
+
+  test("returns [] when threads is not an array", () => {
+    expect(parseThreads('<threads>{"threads":"nope"}</threads>')).toEqual([]);
+  });
+
+  test("filters out non-string and empty entries, trims whitespace", () => {
+    const raw = '<threads>{"threads":["  keep  ", "", 5, "ok"]}</threads>';
+    expect(parseThreads(raw)).toEqual(["keep", "ok"]);
+  });
+
+  test("is case-insensitive on the tag", () => {
+    expect(parseThreads('<THREADS>{"threads":["x"]}</THREADS>')).toEqual(["x"]);
+  });
+});
+
+describe("stripThreads", () => {
+  test("removes the threads block from display text", () => {
+    const raw = 'The core idea.\n<threads>{"threads":["a"]}</threads>';
+    expect(stripThreads(raw)).toBe("The core idea.");
+  });
+
+  test("leaves text without a tag unchanged", () => {
+    expect(stripThreads("no tag here")).toBe("no tag here");
+  });
+
+  test("removes multiple tags if present", () => {
+    const raw = 'a<threads>{}</threads>b<threads>{}</threads>';
+    expect(stripThreads(raw)).toBe("ab");
+  });
+});


### PR DESCRIPTION
Closes #202

## What

The **inner-voice** MFE: a no-send-button thinking interface that streams from the local `coder serve` endpoint (falese/coder#58) after a silence pause, extracts concept threads in real time, and feeds them back into the thought. It's the human input layer for the agentic delivery loop.

Authored as **manifest-driven domain functionality** — `mfe-manifest.yaml` + a self-contained `src/` that lands on top of `remote:generate` output. This is also a working test of the platform's "import domain functionality into a freshly scaffolded MFE" story.

## Layout

- `mfe-manifest.yaml` — `InnerVoice` domain capability + `Load` lifecycle (`onLoadError`, `contained: true`) + `config` block.
- `src/lib/*` — `parseThreads` (extract + strip, never throws), `sse` (incremental parser), `threadLayout` (radial trig), `config` (resolution + fallbacks), `threads` (dedupe/cap), `streamCoder` (coder serve SSE), `streamClaude` (Anthropic demo SSE), `runStream` (local vs demo dispatch), `systemPrompt`, `env`.
- `src/hooks/*` — `usePauseTimer` (debounced silence trigger), `useCoderStream` (streaming state machine), `useThreads` (accumulation).
- `src/features/InnerVoice/*` — three-panel UI (`ThoughtPanel`, `ThreadWeb`, `ThreadNode`, `PulseRing`, `ResponsePanel`, root). Inline styles only, no component libraries.
- `tests/*` — 23 runtime-agnostic unit tests (bun) for the pure core.
- `demo/*` — standalone Vite app (Anthropic API) for GitHub Pages, kept **separate** so `remote:generate --force` never clobbers it.
- `.github/workflows/deploy-inner-voice.yml` — builds the demo and publishes to GitHub Pages.

## Integration (documented in README)

The component resolves through the generator's existing `loadDomainComponent('InnerVoice')`; the only handwritten glue is two overrides in the generated `mfe.ts` — point `loadDomainComponent` at `features/InnerVoice/InnerVoice`, and inject `this.manifest.config` into props via `doRender`. Config also has hardcoded fallbacks, so the MFE runs with no manifest.

## Acceptance criteria — evidence

| Criterion | Evidence |
|---|---|
| No send button; pause-triggered streaming | `usePauseTimer` (debounced, fires after `pauseMs`); no button in any component |
| Countdown bar fills/resets per keystroke | `ThoughtPanel` countdown bar keyed by `restartKey` + `countdownBar` keyframe |
| Progressive token streaming + cursor | `useCoderStream` + `ResponsePanel` live text with `blink` cursor |
| 2–4 radial thread nodes; click re-triggers | `ThreadWeb` + `threadPosition` (spec formula, unit-tested); `followThread` appends + reschedules |
| Thread history accumulates; prior fade; Escape | `useThreads` + `accumulateThreads` (tested); `ResponsePanel` fade formula; `handleEscape` keeps session history |
| `parseThreads` never throws | `tests/parseThreads.test.ts` (malformed JSON / no tag / non-array → `[]`) |
| Config fallbacks | `tests/lib.test.ts` `resolveConfig` (defaults, coercion, garbage) |
| No component libs / no `any` | components use inline `React.CSSProperties` only |
| GitHub Pages deploy | `.github/workflows/deploy-inner-voice.yml` |

## Verification

- `cd examples/inner-voice && bun test tests/` → **23 pass**.
- Isolated `tsc --strict` of the entire `src/lib/` layer → clean.

> ⚠️ Environment note: the CI sandbox blocks the npm registry (HTTP 403) and ships no `node_modules`, so `remote:init`/`remote:generate` and the rspack/Vite builds could not run there — hence the platform scaffold is generated locally (per design) and the React components/hooks (which need React types) were not type-checked, though they depend only on the verified `lib/` layer. The pure-core tests and isolated strict typecheck above pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7NMgbdtPHueJ3zFhaTLoh)_