### PR TITLE
feat(inner-voice): wire episode sessionId + live persona trait dial t…

### DIFF
--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -67,9 +67,53 @@ const colStyle: React.CSSProperties = {
   display: "flex",
 };
 
+// Persona traits (1–7), mirrors coder's src/persona/traits.ts defaults.
+const TRAIT_NAMES = ["formality", "sarcasm", "verbosity"] as const;
+type TraitName = (typeof TRAIT_NAMES)[number];
+const DEFAULT_TRAITS: Record<TraitName, number> = { formality: 4, sarcasm: 1, verbosity: 4 };
+
+function newSessionId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  return c?.randomUUID ? c.randomUUID() : `s-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`;
+}
+
+const controlsStyle: React.CSSProperties = {
+  display: "flex",
+  gap: 14,
+  alignItems: "center",
+  fontFamily: "'JetBrains Mono', monospace",
+  fontSize: 10,
+  color: "var(--muted)",
+};
+
+const TraitControls: React.FC<{
+  traits: Record<string, number>;
+  onChange: (name: TraitName, level: number) => void;
+}> = ({ traits, onChange }) => (
+  <div style={controlsStyle}>
+    {TRAIT_NAMES.map((name) => (
+      <label key={name} style={{ display: "flex", alignItems: "center", gap: 5 }} title={`${name} (1–7)`}>
+        <span>{name.slice(0, 4)}</span>
+        <input
+          type="range"
+          min={1}
+          max={7}
+          step={1}
+          value={traits[name] ?? DEFAULT_TRAITS[name]}
+          onChange={(e) => { onChange(name, Number(e.target.value)); }}
+          style={{ width: 56, accentColor: "var(--accent)" }}
+        />
+        <span style={{ color: "var(--text)" }}>{String(traits[name] ?? DEFAULT_TRAITS[name])}</span>
+      </label>
+    ))}
+  </div>
+);
+
 export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
   const cfg = resolveConfig(config);
   const [thought, setThought] = useState("");
+  const [sessionId, setSessionId] = useState(newSessionId);
+  const [traits, setTraits] = useState<Record<string, number>>(DEFAULT_TRAITS);
   const [turns, setTurns] = useState<string[]>([]);
   // The thought last sent to the model — guards against re-sending identical text
   // (the whole evolving thought IS the prompt; we just never repeat it verbatim).
@@ -94,6 +138,8 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
     coderServeUrl: cfg.coderServeUrl,
     maxTokens: cfg.maxTokens,
     systemPrompt: cfg.systemPrompt,
+    sessionId,
+    traits,
     onComplete,
   });
 
@@ -115,6 +161,10 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
   }, []);
 
   const handleEscape = useCallback(() => {
+    // Esc is the episode boundary: persist the accumulated session, then start
+    // a fresh one. saveSession is a no-op server-side if nothing was recorded.
+    void stream.saveSession();
+    setSessionId(newSessionId());
     setThought("");
     lastSent.current = "";
     stream.reset();
@@ -145,6 +195,10 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
 
       <header style={headerStyle}>
         <span>inner-voice</span>
+        <TraitControls
+          traits={traits}
+          onChange={(name, level) => { setTraits((t) => ({ ...t, [name]: level })); }}
+        />
         <span>{status}</span>
       </header>
 
@@ -185,7 +239,7 @@ export const InnerVoice: React.FC<InnerVoiceProps> = ({ config }) => {
       </main>
 
       <footer style={footerStyle}>
-        no send button — responds after {String(cfg.pauseMs)}ms of silence · esc to clear
+        no send button — responds after {String(cfg.pauseMs)}ms of silence · esc to save session + clear
       </footer>
     </div>
   );

--- a/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/InnerVoice.tsx
@@ -16,8 +16,8 @@ export interface InnerVoiceProps {
 const CSS = `
 @import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital@0;1&family=JetBrains+Mono&display=swap');
 .iv-root {
-  --bg:#040404; --surface:#0d0d0d; --border:#141414;
-  --text:#c8c8c8; --muted:#2a2a2a; --accent:#00ff9f;
+  --bg:#0b0d10; --surface:#14171c; --border:#262b33;
+  --text:#e8eaed; --text-soft:#c6cad0; --muted:#9aa0a8; --accent:#00ff9f;
   background:var(--bg); color:var(--text);
   height:100vh; display:flex; flex-direction:column; overflow:hidden;
 }

--- a/examples/inner-voice/src/features/InnerVoice/ResponsePanel.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ResponsePanel.tsx
@@ -43,14 +43,14 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
     minHeight: 0,
     overflowY: "auto",
     fontFamily: "'EB Garamond', serif",
-    fontSize: 17,
-    lineHeight: 1.8,
+    fontSize: 18,
+    lineHeight: 1.7,
     color: "var(--text)",
-    padding: "8px 4px",
+    padding: "12px 6px",
   };
   const meta: React.CSSProperties = {
     fontFamily: "'JetBrains Mono', monospace",
-    fontSize: 10,
+    fontSize: 11,
     color: "var(--muted)",
     marginTop: 6,
   };
@@ -67,7 +67,7 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
   };
   const chip: React.CSSProperties = {
     fontFamily: "'JetBrains Mono', monospace",
-    fontSize: 10,
+    fontSize: 11,
     color: "var(--text)",
     background: "var(--surface)",
     border: "1px solid var(--border)",
@@ -75,18 +75,17 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
     padding: "2px 6px",
     cursor: "pointer",
   };
-  // The model's reasoning rendered as a second inner voice — italic, accent-tinted,
-  // indented behind a thin rule, dimmer than the crystallized answer.
+  // The model's reasoning rendered as a second inner voice — italic, set off by a
+  // thin accent rule, softer than the crystallized answer but still legible.
   const innerVoice: React.CSSProperties = {
     fontFamily: "'EB Garamond', serif",
     fontStyle: "italic",
-    fontSize: 15,
+    fontSize: 16,
     lineHeight: 1.7,
-    color: "var(--accent)",
-    opacity: 0.55,
+    color: "var(--text-soft)",
     borderLeft: "2px solid var(--accent)",
     paddingLeft: 12,
-    margin: "0 0 12px",
+    margin: "0 0 14px",
     whiteSpace: "pre-wrap",
   };
   const cursor = (
@@ -109,7 +108,7 @@ export const ResponsePanel: React.FC<ResponsePanelProps> = ({
         {priors.map((text, i) => (
           <p
             key={`prior-${String(i)}`}
-            style={{ opacity: 0.15 + (i / Math.max(priors.length, 1)) * 0.2, margin: "0 0 14px" }}
+            style={{ opacity: 0.35 + (i / Math.max(priors.length, 1)) * 0.35, margin: "0 0 14px" }}
           >
             {text}
           </p>

--- a/examples/inner-voice/src/features/InnerVoice/ThoughtPanel.tsx
+++ b/examples/inner-voice/src/features/InnerVoice/ThoughtPanel.tsx
@@ -43,22 +43,27 @@ export const ThoughtPanel: React.FC<ThoughtPanelProps> = ({
     flex: 1,
     minHeight: 0,
     width: "100%",
+    maxWidth: 680,
+    marginInline: "auto",
     resize: "none",
     border: "none",
     outline: "none",
     background: "transparent",
     color: "var(--text)",
+    caretColor: "var(--accent)",
     fontFamily: "'EB Garamond', serif",
-    fontSize: 17,
-    lineHeight: 1.8,
-    padding: "8px 4px",
+    fontSize: 20,
+    lineHeight: 1.7,
+    letterSpacing: "0.01em",
+    padding: "16px 8px",
   };
   const hint: React.CSSProperties = {
     flex: "0 0 auto",
     fontFamily: "'JetBrains Mono', monospace",
-    fontSize: 10,
+    fontSize: 11,
     color: "var(--muted)",
-    padding: "0 4px 4px",
+    padding: "0 8px 6px",
+    textAlign: "center",
   };
   return (
     <div style={wrap}>

--- a/examples/inner-voice/src/hooks/useCoderStream.ts
+++ b/examples/inner-voice/src/hooks/useCoderStream.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { runStream } from "../lib/runStream";
+import { saveEpisode, type Traits } from "../lib/streamCoder";
 import { stripThreads } from "../lib/parseThreads";
 
 export interface StreamMetrics {
@@ -11,6 +12,10 @@ export interface UseCoderStreamArgs {
   coderServeUrl: string;
   maxTokens: number;
   systemPrompt: string;
+  /** Episode grouping; when set, exchanges are recorded server-side under this id. */
+  sessionId?: string;
+  /** Persona dial sent with every generation. */
+  traits?: Traits;
   /** Called with the full RAW final + thought text (threads tags intact) when a stream ends. */
   onComplete?: (final: string, thought: string, metrics: StreamMetrics) => void;
 }
@@ -25,6 +30,8 @@ export interface UseCoderStreamResult {
   metrics: StreamMetrics | null;
   start: (prompt: string) => void;
   reset: () => void;
+  /** Persist the current session as an episode (coder serve). Resolves to success. */
+  saveSession: () => Promise<boolean>;
 }
 
 /**
@@ -33,7 +40,7 @@ export interface UseCoderStreamResult {
  * streaming state, timing metrics, and any error. Aborts in-flight requests on
  * a new start, on reset, and on unmount.
  */
-export function useCoderStream({ coderServeUrl, maxTokens, systemPrompt, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
+export function useCoderStream({ coderServeUrl, maxTokens, systemPrompt, sessionId, traits, onComplete }: UseCoderStreamArgs): UseCoderStreamResult {
   const [display, setDisplay] = useState("");
   const [thinking, setThinking] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
@@ -42,6 +49,12 @@ export function useCoderStream({ coderServeUrl, maxTokens, systemPrompt, onCompl
   const abortRef = useRef<AbortController | null>(null);
   const onCompleteRef = useRef(onComplete);
   onCompleteRef.current = onComplete;
+  // Read session/traits from refs so `start` stays stable across renders (traits
+  // is a fresh object each render; the pause-timer closure must not go stale).
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+  const traitsRef = useRef(traits);
+  traitsRef.current = traits;
 
   const start = useCallback(
     (prompt: string) => {
@@ -59,6 +72,8 @@ export function useCoderStream({ coderServeUrl, maxTokens, systemPrompt, onCompl
         coderServeUrl,
         maxTokens,
         system: systemPrompt,
+        sessionId: sessionIdRef.current,
+        traits: traitsRef.current,
         signal: ac.signal,
         onChunk: (final, thought) => {
           setDisplay(stripThreads(final));
@@ -89,7 +104,13 @@ export function useCoderStream({ coderServeUrl, maxTokens, systemPrompt, onCompl
     setIsStreaming(false);
   }, []);
 
+  const saveSession = useCallback(async (): Promise<boolean> => {
+    const id = sessionIdRef.current;
+    if (!id) return false;
+    return saveEpisode(coderServeUrl, id);
+  }, [coderServeUrl]);
+
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  return { display, thinking, isStreaming, error, metrics, start, reset };
+  return { display, thinking, isStreaming, error, metrics, start, reset, saveSession };
 }

--- a/examples/inner-voice/src/lib/runStream.ts
+++ b/examples/inner-voice/src/lib/runStream.ts
@@ -1,4 +1,4 @@
-import type { StreamHandlers } from "./streamCoder";
+import type { StreamHandlers, Traits } from "./streamCoder";
 import { streamCoder } from "./streamCoder";
 import { streamClaude } from "./streamClaude";
 import { isDemoMode, anthropicApiKey, anthropicModel } from "./env";
@@ -8,6 +8,10 @@ export interface RunStreamOptions extends StreamHandlers {
   coderServeUrl: string;
   maxTokens?: number;
   system?: string;
+  /** Episode grouping (coder serve only; ignored in demo/Claude mode). */
+  sessionId?: string;
+  /** Persona dial (coder serve only; ignored in demo/Claude mode). */
+  traits?: Traits;
   signal?: AbortSignal;
 }
 
@@ -41,6 +45,8 @@ export function runStream(opts: RunStreamOptions): Promise<void> {
     prompt: opts.prompt,
     maxTokens: opts.maxTokens,
     system: opts.system,
+    sessionId: opts.sessionId,
+    traits: opts.traits,
     signal: opts.signal,
   });
 }

--- a/examples/inner-voice/src/lib/streamCoder.ts
+++ b/examples/inner-voice/src/lib/streamCoder.ts
@@ -10,12 +10,67 @@ export interface StreamHandlers {
   onError: (message: string) => void;
 }
 
+/** Dialable persona traits (1–7), folded into the system prompt server-side. */
+export type Traits = Record<string, number>;
+
 export interface StreamCoderOptions extends StreamHandlers {
   url: string;
   prompt: string;
   system?: string;
   maxTokens?: number;
+  /** Groups exchanges into one episode server-side; enables episode capture. */
+  sessionId?: string;
+  /** Persona dial (e.g. { sarcasm: 5 }); merged into the system prompt by coder serve. */
+  traits?: Traits;
   signal?: AbortSignal;
+}
+
+export interface GenerateRequestBody {
+  prompt: string;
+  system: string;
+  maxTokens: number;
+  sessionId?: string;
+  traits?: Traits;
+}
+
+/**
+ * Build the `/generate` request body, including `sessionId`/`traits` only when
+ * present (so single-shot requests stay unchanged). Pure — unit-testable.
+ */
+export function buildGenerateBody(opts: {
+  prompt: string;
+  system: string;
+  maxTokens: number;
+  sessionId?: string;
+  traits?: Traits;
+}): GenerateRequestBody {
+  const body: GenerateRequestBody = {
+    prompt: opts.prompt,
+    system: opts.system,
+    maxTokens: opts.maxTokens,
+  };
+  if (opts.sessionId) body.sessionId = opts.sessionId;
+  if (opts.traits && Object.keys(opts.traits).length > 0) body.traits = opts.traits;
+  return body;
+}
+
+/**
+ * Persist the accumulated session as an episode (coder serve `POST /episodes/save`).
+ * Total — never throws; returns whether the save succeeded (404 = nothing recorded).
+ */
+export async function saveEpisode(url: string, sessionId: string, signal?: AbortSignal): Promise<boolean> {
+  const endpoint = `${url.replace(/\/$/, "")}/episodes/save`;
+  try {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId }),
+      signal,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }
 
 function corsHelp(url: string): string {
@@ -32,7 +87,7 @@ function corsHelp(url: string): string {
  * `onError` rather than thrown, so the UI can degrade gracefully.
  */
 export async function streamCoder(opts: StreamCoderOptions): Promise<void> {
-  const { url, prompt, system = SYSTEM_PROMPT, maxTokens = 512, signal } = opts;
+  const { url, prompt, system = SYSTEM_PROMPT, maxTokens = 512, sessionId, traits, signal } = opts;
   const endpoint = `${url.replace(/\/$/, "")}/generate`;
 
   let response: Response;
@@ -40,7 +95,7 @@ export async function streamCoder(opts: StreamCoderOptions): Promise<void> {
     response = await fetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt, system, maxTokens }),
+      body: JSON.stringify(buildGenerateBody({ prompt, system, maxTokens, sessionId, traits })),
       signal,
     });
   } catch (err) {

--- a/examples/inner-voice/tests/streamCoder.test.ts
+++ b/examples/inner-voice/tests/streamCoder.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from "bun:test";
+import { buildGenerateBody, saveEpisode } from "../src/lib/streamCoder";
+
+describe("buildGenerateBody", () => {
+  test("includes only prompt/system/maxTokens by default", () => {
+    expect(buildGenerateBody({ prompt: "p", system: "s", maxTokens: 100 })).toEqual({
+      prompt: "p",
+      system: "s",
+      maxTokens: 100,
+    });
+  });
+
+  test("includes sessionId and non-empty traits when provided", () => {
+    expect(
+      buildGenerateBody({ prompt: "p", system: "s", maxTokens: 100, sessionId: "s1", traits: { sarcasm: 5 } }),
+    ).toEqual({ prompt: "p", system: "s", maxTokens: 100, sessionId: "s1", traits: { sarcasm: 5 } });
+  });
+
+  test("omits an empty traits object and an empty sessionId", () => {
+    const b = buildGenerateBody({ prompt: "p", system: "s", maxTokens: 100, traits: {}, sessionId: "" });
+    expect(b.traits).toBeUndefined();
+    expect(b.sessionId).toBeUndefined();
+  });
+});
+
+describe("saveEpisode", () => {
+  test("POSTs the sessionId to /episodes/save and returns ok", async () => {
+    const calls: { url: unknown; init: RequestInit }[] = [];
+    const orig = globalThis.fetch;
+    globalThis.fetch = ((url: unknown, init: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve({ ok: true } as Response);
+    }) as typeof fetch;
+    try {
+      const ok = await saveEpisode("http://localhost:3991/", "s1");
+      expect(ok).toBe(true);
+      expect(calls[0].url).toBe("http://localhost:3991/episodes/save");
+      expect(JSON.parse(calls[0].init.body as string)).toEqual({ sessionId: "s1" });
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  test("returns false on network failure (never throws)", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = (() => Promise.reject(new Error("down"))) as typeof fetch;
+    try {
+      expect(await saveEpisode("http://x", "s1")).toBe(false);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+});


### PR DESCRIPTION
…o coder serve

The inner-voice client only sent {prompt, system, maxTokens}, so coder serve never recorded episodes (it records only when a sessionId is present) and the persona traits couldn't be dialed from the UI. Wire both:

- streamCoder: add sessionId + traits to the /generate body via a pure, testable buildGenerateBody; add saveEpisode() -> POST /episodes/save.
- runStream/useCoderStream: thread sessionId + traits through (read from refs so `start` stays stable for the pause timer); expose saveSession().
- InnerVoice: mint a sessionId per thinking session; Esc now persists the session as an episode then rolls a fresh id; add formality/sarcasm/verbosity sliders (1-7, defaults mirror coder's src/persona/traits.ts) sent as `traits`.

Now a thinking session in the UI creates an episode on Esc (idle-flush is the server-side safety net), and sarcasm/formality/verbosity are adjustable live (folded into the system prompt server-side, no retrain).

Tests: buildGenerateBody (field inclusion/omission) + saveEpisode (POST shape, network-failure tolerance). 28/28 inner-voice lib tests pass under `bun test`.

https://claude.ai/code/session_01YXSXnrQYgLtvccTgpsutiu