### PR TITLE
feat(governance): the ADR implementation lifecycle (ADR-075 §6)

### DIFF
--- a/docs/architecture-decisions/ADR-001-lifecycle-reentrancy-guard.md
+++ b/docs/architecture-decisions/ADR-001-lifecycle-reentrancy-guard.md
@@ -10,7 +10,8 @@ tags: [runtime, lifecycle, base-mfe, safety]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/base-mfe.ts
 verified-by: []
 summary: >-
   Introduce a re-entrancy guard in BaseMFE that tracks executing {capability, phase} pairs and

--- a/docs/architecture-decisions/ADR-002-lifecycle-hook-execution-model.md
+++ b/docs/architecture-decisions/ADR-002-lifecycle-hook-execution-model.md
@@ -10,7 +10,8 @@ tags: [runtime, lifecycle, hooks, resilience]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/base-mfe.ts
 verified-by: []
 summary: >-
   Hooks use a contained execution model where before/after/error phase failures are silently

--- a/docs/architecture-decisions/ADR-003-no-custom-lifecycle-phases.md
+++ b/docs/architecture-decisions/ADR-003-no-custom-lifecycle-phases.md
@@ -10,7 +10,8 @@ tags: [dsl, lifecycle, simplicity]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/dsl/src/schema.ts
 verified-by: []
 summary: >-
   The DSL lifecycle is restricted to exactly four standard phases — before, main, after, error —

--- a/docs/architecture-decisions/ADR-004-handler-array-support.md
+++ b/docs/architecture-decisions/ADR-004-handler-array-support.md
@@ -10,7 +10,8 @@ tags: [dsl, lifecycle, handlers]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/dsl/src/schema.ts
 verified-by: []
 summary: >-
   The DSL handler field accepts either a single string or an array of strings; semantics differ

--- a/docs/architecture-decisions/ADR-005-handler-discovery-convention.md
+++ b/docs/architecture-decisions/ADR-005-handler-discovery-convention.md
@@ -10,7 +10,9 @@ tags: [dsl, handlers, codegen, polyglot]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/codegen/src/unified-generator.ts
+  - packages/codegen/templates/base-mfe/handler-registry.ts.ejs
 verified-by: []
 summary: >-
   DSL handler names are neutral strings; code generators map them to language-specific

--- a/docs/architecture-decisions/ADR-006-unified-type-system.md
+++ b/docs/architecture-decisions/ADR-006-unified-type-system.md
@@ -10,7 +10,8 @@ tags: [dsl, types, graphql, typescript]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/dsl/src/type-system.ts
 verified-by: []
 summary: >-
   A single type system flows from the DSL through GraphQL schema to TypeScript/Python types;

--- a/docs/architecture-decisions/ADR-008-data-type-metadata.md
+++ b/docs/architecture-decisions/ADR-008-data-type-metadata.md
@@ -10,7 +10,8 @@ tags: [dsl, types, metadata, registry]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/dsl/src/schema.ts
 verified-by: []
 summary: >-
   DSL type definitions carry owner and tags metadata fields to support registry search,

--- a/docs/architecture-decisions/ADR-009-language-field-template-selection.md
+++ b/docs/architecture-decisions/ADR-009-language-field-template-selection.md
@@ -10,8 +10,10 @@ tags: [dsl, codegen, language, templates]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - packages/codegen/src/unified-generator.ts
+verified-by:
+  - check:mfe-drift:check
 summary: >-
   The DSL language field drives template selection and build tooling; V1 supports JavaScript and
   TypeScript only, with non-JS backends treated as data-only services consumed by a JS shell.

--- a/docs/architecture-decisions/ADR-010-data-lifecycle-alignment.md
+++ b/docs/architecture-decisions/ADR-010-data-lifecycle-alignment.md
@@ -10,7 +10,8 @@ tags: [dsl, lifecycle, data]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/dsl/src/schema.ts
 verified-by: []
 summary: >-
   Data queries and mutations use the same four-phase lifecycle as capability execution; there is

--- a/docs/architecture-decisions/ADR-011-generated-from-traceability.md
+++ b/docs/architecture-decisions/ADR-011-generated-from-traceability.md
@@ -10,7 +10,8 @@ tags: [dsl, data, traceability, lineage]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/bff-plugin/templates/mfe-manifest.yaml.ejs
 verified-by: []
 summary: >-
   The DSL data section includes a generatedFrom field that records the source API specifications

--- a/docs/architecture-decisions/ADR-012-graphql-mesh-bff-layer.md
+++ b/docs/architecture-decisions/ADR-012-graphql-mesh-bff-layer.md
@@ -10,7 +10,9 @@ tags: [bff, graphql, mesh, dsl]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/bff-plugin/templates/server.ts.ejs
+  - packages/bff-plugin/templates/meshrc.yaml.ejs
 verified-by: []
 summary: >-
   Use GraphQL Mesh as the BFF passthrough layer with configuration embedded directly in the MFE

--- a/docs/architecture-decisions/ADR-013-generated-mfe-test-templates.md
+++ b/docs/architecture-decisions/ADR-013-generated-mfe-test-templates.md
@@ -10,7 +10,9 @@ tags: [testing, codegen, scaffolding, tdd]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/codegen/templates/base-mfe/mfe.test.ts.ejs
+  - packages/codegen/templates/base-mfe-angular/mfe.test.ts.ejs
 verified-by: []
 summary: >-
   Every scaffolded MFE project includes working test files that teams can run immediately and

--- a/docs/architecture-decisions/ADR-014-incremental-typescript-migration.md
+++ b/docs/architecture-decisions/ADR-014-incremental-typescript-migration.md
@@ -10,8 +10,10 @@ tags: [typescript, migration, codegen]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - tsconfig.json
+verified-by:
+  - typecheck
 summary: >-
   New CLI code and recently-completed modules are written in TypeScript; existing JavaScript
   remains until touched, with ts-node inline registration enabling a mixed JS/TS codebase.

--- a/docs/architecture-decisions/ADR-015-oclif-migration.md
+++ b/docs/architecture-decisions/ADR-015-oclif-migration.md
@@ -10,7 +10,9 @@ tags: [cli, oclif, commander, migration, plugin-architecture]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - bin/run.js
+  - bin/dev.ts
 verified-by: []
 summary: >-
   Replace the Commander-based CLI with oclif, adopting colon-topic command structure, plugin

--- a/docs/architecture-decisions/ADR-019-mcp-child-process-isolation.md
+++ b/docs/architecture-decisions/ADR-019-mcp-child-process-isolation.md
@@ -10,7 +10,9 @@ tags: [mcp, child-process, isolation, ai-native, concurrency]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - src/commands/mcp/serve.ts
+  - src/mcp/tool-registry.ts
 verified-by: []
 summary: >-
   Each MCP tool call spawns seans-mfe-tool <cmd> --json as a child process, parses stdout as

--- a/docs/architecture-decisions/ADR-020-bun-node-split.md
+++ b/docs/architecture-decisions/ADR-020-bun-node-split.md
@@ -10,7 +10,9 @@ tags: [cli, bun, node, dev-experience, publish]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - bin/dev.ts
+  - bin/run.js
 verified-by: []
 summary: >-
   bin/dev.ts runs under Bun for zero-transpile development iteration; bin/run.js is the

--- a/docs/architecture-decisions/ADR-021-package-namespace-strategy.md
+++ b/docs/architecture-decisions/ADR-021-package-namespace-strategy.md
@@ -10,7 +10,8 @@ tags: [packages, namespace, oclif, monorepo, plugin-architecture]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - CLAUDE.md
 verified-by: []
 summary: >-
   Shared platform packages use the @seans-mfe/* namespace (contracts, oclif-base, runtime,

--- a/docs/architecture-decisions/ADR-022-plugin-first-architecture.md
+++ b/docs/architecture-decisions/ADR-022-plugin-first-architecture.md
@@ -10,7 +10,8 @@ tags: [plugin-architecture, oclif, monorepo, daemon, coder]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - CLAUDE.md
 verified-by: []
 summary: >-
   The daemon and coder toolsets ship as separate oclif plugins depending on @seans-mfe/contracts

--- a/docs/architecture-decisions/ADR-023-no-any-typescript-discipline.md
+++ b/docs/architecture-decisions/ADR-023-no-any-typescript-discipline.md
@@ -10,8 +10,11 @@ tags: [typescript, type-safety, contracts, code-quality]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - CLAUDE.md
+  - eslint.config.js
+verified-by:
+  - lint
 summary: >-
   The any type is forbidden in all src/ and packages/ code; unknown is used at system boundaries
   and narrowed via type guards or Zod parse before use.

--- a/docs/architecture-decisions/ADR-025-platform-handler-interface.md
+++ b/docs/architecture-decisions/ADR-025-platform-handler-interface.md
@@ -13,7 +13,8 @@ tags: [runtime, platform-handlers, lifecycle, interfaces, registry]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/base-mfe.ts
 verified-by: []
 summary: >-
   Define a PlatformHandler interface with name/phases/errorConfig/execute contract, a

--- a/docs/architecture-decisions/ADR-026-load-capability-atomic.md
+++ b/docs/architecture-decisions/ADR-026-load-capability-atomic.md
@@ -13,7 +13,8 @@ tags: [runtime, load, atomic, telemetry, module-federation]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/base-mfe.ts
 verified-by: []
 summary: >-
   Implement load as three sequential atomic subphases (entry → mount → enable-render) with

--- a/docs/architecture-decisions/ADR-027-mesh-v0100-plugins.md
+++ b/docs/architecture-decisions/ADR-027-mesh-v0100-plugins.md
@@ -10,7 +10,8 @@ tags: [bff, graphql-mesh, production, codegen, performance, observability]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/bff-plugin/templates/server.ts.ejs
 verified-by: []
 summary: >-
   Lock BFF templates to GraphQL Mesh v0.100.x, adopt the createBuiltMeshHTTPHandler() runtime

--- a/docs/architecture-decisions/ADR-033-two-headed-giant-developer-model.md
+++ b/docs/architecture-decisions/ADR-033-two-headed-giant-developer-model.md
@@ -10,7 +10,8 @@ tags: [dx, ai, cli, meta]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - CLAUDE.md
 verified-by: []
 summary: >-
   The target developer of seans-mfe-tool is a two-headed giant — one head is an AI agent that

--- a/docs/architecture-decisions/ADR-034-pluggable-bundler-framework.md
+++ b/docs/architecture-decisions/ADR-034-pluggable-bundler-framework.md
@@ -1,7 +1,7 @@
 ---
 id: 0034
 title: Pluggable bundler + framework via codegen variants
-status: Accepted
+status: Implemented
 date: 2026-05-21
 deciders: [sean]
 area: Codegen / polyglot
@@ -10,8 +10,10 @@ tags: [codegen, bundler, framework, mfe, module-federation]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - packages/codegen/src/unified-generator.ts
+verified-by:
+  - check:mfe-drift:check
 summary: >-
   Add optional manifest fields `framework` and `bundler` that drive codegen template variant
   selection in UnifiedGenerator, alongside a new concrete runtime class `AngularRemoteMFE` that

--- a/docs/architecture-decisions/ADR-035-docker-turborepo-integration.md
+++ b/docs/architecture-decisions/ADR-035-docker-turborepo-integration.md
@@ -1,7 +1,7 @@
 ---
 id: 0035
 title: Docker Build Orchestration via Turborepo Task Graph
-status: Accepted
+status: Implemented
 date: 2026-05-24
 deciders: [sean]
 area: Docker / CI
@@ -10,7 +10,8 @@ tags: [docker, turborepo, build, ci, infra]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - turbo.json
 verified-by: []
 summary: >-
   Bring Docker builds into the Turborepo task graph so that `turbo run docker:build:examples`

--- a/docs/architecture-decisions/ADR-036-framework-plugins.md
+++ b/docs/architecture-decisions/ADR-036-framework-plugins.md
@@ -1,7 +1,7 @@
 ---
 id: 0036
 title: Framework plugins — abstract BaseFrameworkPlugin with concrete implementations
-status: Accepted
+status: Implemented
 date: 2026-05-25
 deciders: [sean]
 area: Build / codegen / deploy

--- a/docs/architecture-decisions/ADR-037-tdd-always.md
+++ b/docs/architecture-decisions/ADR-037-tdd-always.md
@@ -10,7 +10,8 @@ tags: [testing, tdd, quality, process]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - CLAUDE.md
 verified-by: []
 summary: >-
   Every production code change must be preceded by a failing test; no code is written without a

--- a/docs/architecture-decisions/ADR-038-conventional-commits-branch-discipline.md
+++ b/docs/architecture-decisions/ADR-038-conventional-commits-branch-discipline.md
@@ -10,7 +10,8 @@ tags: [git, commits, branch-naming, process, traceability]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - CLAUDE.md
 verified-by: []
 summary: >-
   All commits use Conventional Commits format (feat/fix/refactor/test/docs/chore) with Refs

--- a/docs/architecture-decisions/ADR-039-structured-logger-no-console-log.md
+++ b/docs/architecture-decisions/ADR-039-structured-logger-no-console-log.md
@@ -10,8 +10,10 @@ tags: [logging, observability, cli, production-code]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - CLAUDE.md
+verified-by:
+  - lint
 summary: >-
   Production src/ and packages/ code uses the structured logger from @seans-mfe/oclif-base;
   console.log is forbidden outside tests and scripts.

--- a/docs/architecture-decisions/ADR-040-manifest-declared-handler-sources.md
+++ b/docs/architecture-decisions/ADR-040-manifest-declared-handler-sources.md
@@ -1,7 +1,7 @@
 ---
 id: 0040
 title: Manifest-Declared Handler Sources
-status: Accepted
+status: Implemented
 date: 2026-05-27
 deciders: [sean]
 area: DSL / handlers / codegen
@@ -10,7 +10,9 @@ tags: [dsl, lifecycle, handlers, codegen, source, di, traceability]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/dsl/src/schema.ts
+  - packages/codegen/src/unified-generator.ts
 verified-by: []
 summary: >-
   Extend LifecycleHookSchema with an optional `source` field so a manifest hook can declare

--- a/docs/architecture-decisions/ADR-041-base-mfe-abstract-base.md
+++ b/docs/architecture-decisions/ADR-041-base-mfe-abstract-base.md
@@ -1,7 +1,7 @@
 ---
 id: 0041
 title: BaseMFE Abstract Base Class & Platform Capability Contract
-status: Accepted
+status: Implemented
 date: 2026-05-28
 deciders: [sean]
 area: Runtime / base-class

--- a/docs/architecture-decisions/ADR-042-mfe-lifecycle-state-machine.md
+++ b/docs/architecture-decisions/ADR-042-mfe-lifecycle-state-machine.md
@@ -1,7 +1,7 @@
 ---
 id: 0042
 title: MFE Lifecycle State Machine
-status: Accepted
+status: Implemented
 date: 2026-05-28
 deciders: [sean]
 area: Runtime lifecycle
@@ -10,7 +10,8 @@ tags: [runtime, lifecycle, state-machine, invariants]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/base-mfe.ts
 verified-by: []
 summary: >-
   BaseMFE models its lifecycle as an explicit six-state machine (`uninitialized → loading →

--- a/docs/architecture-decisions/ADR-043-manifest-driven-codegen.md
+++ b/docs/architecture-decisions/ADR-043-manifest-driven-codegen.md
@@ -1,7 +1,7 @@
 ---
 id: 0043
 title: Manifest-Driven Code Generation Pipeline
-status: Accepted
+status: Implemented
 date: 2026-05-28
 deciders: [sean]
 area: Codegen / DSL

--- a/docs/architecture-decisions/ADR-044-production-container-hardening.md
+++ b/docs/architecture-decisions/ADR-044-production-container-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: 0044
 title: Production Container Hardening for Generated MFEs
-status: Accepted
+status: Implemented
 date: 2026-05-28
 deciders: [sean]
 area: Docker / deploy / security
@@ -10,7 +10,8 @@ tags: [docker, nginx, kubernetes, security, deploy, generated-output, non-root]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/bff-plugin/templates/Dockerfile.ejs
 verified-by: []
 summary: >-
   Generated MFE containers run as non-root on unprivileged nginx (port 8080), ship a hardened

--- a/docs/architecture-decisions/ADR-051-angular-19-upgrade.md
+++ b/docs/architecture-decisions/ADR-051-angular-19-upgrade.md
@@ -10,7 +10,8 @@ tags: [angular, security, codegen, dependencies, vulnerability]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/codegen/templates/base-mfe-angular/package.json.ejs
 verified-by: []
 summary: >-
   Upgrade Angular from ^17.0.0 to ^19.2.16 in all generated Angular MFE templates and runtime

--- a/docs/architecture-decisions/ADR-052-bff-demo-mode-mock-switch.md
+++ b/docs/architecture-decisions/ADR-052-bff-demo-mode-mock-switch.md
@@ -10,7 +10,9 @@ tags: [bff, graphql-mesh, mock, demo-mode, codegen, dsl]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/bff-plugin/templates/mock-switch.js.ejs
+  - packages/bff-plugin/templates/mocks.json.ejs
 verified-by: []
 summary: >-
   Generated BFFs gain an opt-in "demo mode" — they serve live upstream data by default but

--- a/docs/architecture-decisions/ADR-053-remote-mfe-doquery.md
+++ b/docs/architecture-decisions/ADR-053-remote-mfe-doquery.md
@@ -10,7 +10,8 @@ tags: [runtime, base-mfe, remote-mfe, bff, doquery, codegen]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/remote-mfe.ts
 verified-by: []
 summary: >-
   The RemoteMFE.doQuery override that threw "Query not supported for remote MFE type" is

--- a/docs/architecture-decisions/ADR-054-control-plane-message-protocol.md
+++ b/docs/architecture-decisions/ADR-054-control-plane-message-protocol.md
@@ -10,7 +10,8 @@ tags: [contracts, daemon, control-plane, runtime, protocol, messages]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/contracts/src/messages.ts
 verified-by: []
 summary: >-
   The Renderer ⇄ Daemon ⇄ Registry ⇄ MFE wire protocol (PLATFORM-CONTRACT.md v3.2) is codified

--- a/docs/architecture-decisions/ADR-055-layout-manager-daemon-driven-shells.md
+++ b/docs/architecture-decisions/ADR-055-layout-manager-daemon-driven-shells.md
@@ -10,7 +10,8 @@ tags: [runtime, layout, shell, slots, daemon, control-plane, module-federation]
 relates-to: []
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/layout-manager.ts
 verified-by: []
 summary: >-
   `src/runtime/layout-manager.ts` adds a framework-free LayoutManager that turns any shell into

--- a/docs/architecture-decisions/ADR-056-mfe-presentation-boundary.md
+++ b/docs/architecture-decisions/ADR-056-mfe-presentation-boundary.md
@@ -1,7 +1,7 @@
 ---
 id: 0056
 title: MFE Presentation Boundary and Host-Side Composition Providers (Polyglot VM Model)
-status: Accepted
+status: Implemented
 date: 2026-06-13
 deciders: [sean]
 area: Runtime / boundary / providers / polyglot
@@ -10,7 +10,8 @@ tags: [runtime, boundary, providers, polyglot, module-federation, react, angular
 relates-to: []
 supersedes: []
 superseded-by: [60]
-implemented-by: []
+implemented-by:
+  - packages/contracts/src/presentation.ts
 verified-by: []
 summary: >-
   An MFE is a sealed, framework-opaque virtual machine composed like a Helm chart — never

--- a/docs/architecture-decisions/ADR-057-virtualized-daemon-socket.md
+++ b/docs/architecture-decisions/ADR-057-virtualized-daemon-socket.md
@@ -10,7 +10,8 @@ tags: [runtime, control-plane, channels]
 relates-to: [41, 54, 55, 56]
 supersedes: []
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/daemon-channel.ts
 verified-by: []
 long-form: true
 ---

--- a/docs/architecture-decisions/ADR-058-slot-provider-mfes.md
+++ b/docs/architecture-decisions/ADR-058-slot-provider-mfes.md
@@ -10,7 +10,8 @@ tags: [runtime, slots, composition]
 relates-to: [55, 56, 57]
 supersedes: []
 superseded-by: [68]
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/layout-manager.ts
 verified-by: []
 long-form: true
 ---

--- a/docs/architecture-decisions/ADR-059-base-control-plane.md
+++ b/docs/architecture-decisions/ADR-059-base-control-plane.md
@@ -1,7 +1,7 @@
 ---
 id: 0059
 title: "BaseControlPlane: abstract base for all control-plane implementations"
-status: Accepted
+status: Implemented
 date: 2026-06-14
 deciders: [sean]
 area: Runtime / control-plane / abstract-base
@@ -10,8 +10,10 @@ tags: [runtime, control-plane, abstract-base]
 relates-to: [54, 55, 56, 57, 58]
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - packages/runtime/src/base-control-plane.ts
+verified-by:
+  - packages/runtime/src/base-control-plane.test.ts
 long-form: true
 ---
 

--- a/docs/architecture-decisions/ADR-060-contextualized-vm-composition.md
+++ b/docs/architecture-decisions/ADR-060-contextualized-vm-composition.md
@@ -1,7 +1,7 @@
 ---
 id: 0060
 title: "Contextualized VM composition: value-injection, slot-scoped self-healing, and control-plane re-resolution"
-status: Accepted
+status: Implemented
 date: 2026-06-15
 deciders: [sean]
 area: Runtime / composition / resilience / context
@@ -10,7 +10,9 @@ tags: [runtime, composition, resilience, context]
 relates-to: [30, 41, 42, 54, 55, 56, 57, 58, 59]
 supersedes: [56]
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/runtime/src/layout-adaptors.ts
+  - packages/runtime/src/error-boundary.ts
 verified-by: []
 long-form: true
 ---

--- a/docs/architecture-decisions/ADR-061-dsl-and-codegen-as-packages.md
+++ b/docs/architecture-decisions/ADR-061-dsl-and-codegen-as-packages.md
@@ -1,7 +1,7 @@
 ---
 id: 0061
 title: "`@seans-mfe/dsl` and `@seans-mfe/codegen` as first-class packages; framework variant is injected, not resolved"
-status: Accepted
+status: Implemented
 date: 2026-07-01
 deciders: [sean]
 area: Codegen / DSL / packaging

--- a/docs/architecture-decisions/ADR-062-deploy-is-dev-convenience-production-is-a-plugin-axis.md
+++ b/docs/architecture-decisions/ADR-062-deploy-is-dev-convenience-production-is-a-plugin-axis.md
@@ -2,6 +2,9 @@
 id: 0062
 title: "`deploy` is a dev-convenience wrapper; production deployment returns as a plugin-resolved target axis"
 status: Accepted
+impl:
+  stage: deferred
+  refs: ["#250"]
 date: 2026-07-01
 deciders: [sean]
 area: Deploy / plugins / scope

--- a/docs/architecture-decisions/ADR-066-stable-slot-addressing-desired-state-placement.md
+++ b/docs/architecture-decisions/ADR-066-stable-slot-addressing-desired-state-placement.md
@@ -1,7 +1,7 @@
 ---
 id: 0066
 title: Stable slot addressing and desired-state placement
-status: Accepted
+status: Implemented
 date: 2026-07-11
 deciders: [sean]
 area: Runtime / slots / addressing / control-plane
@@ -10,8 +10,10 @@ tags: [runtime, slots, addressing, control-plane]
 relates-to: [55, 57, 58, 60]
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - packages/contracts/src/slot-contract.ts
+verified-by:
+  - check:mfe-consistency
 long-form: true
 ---
 

--- a/docs/architecture-decisions/ADR-067-manifest-declared-slot-contract.md
+++ b/docs/architecture-decisions/ADR-067-manifest-declared-slot-contract.md
@@ -1,7 +1,7 @@
 ---
 id: 0067
 title: "Manifest-declared slot contract: slots are declared in the DSL, code is generated from the declaration"
-status: Accepted
+status: Implemented
 date: 2026-07-11
 deciders: [sean]
 area: DSL / codegen / slots / contract
@@ -10,8 +10,11 @@ tags: [dsl, codegen, slots, contract]
 relates-to: [43, 57, 58, 66]
 supersedes: []
 superseded-by: []
-implemented-by: []
-verified-by: []
+implemented-by:
+  - packages/codegen/templates/base-mfe/slots.tsx.ejs
+  - packages/codegen/templates/base-mfe-angular/slots.ts.ejs
+verified-by:
+  - check:mfe-drift:check
 long-form: true
 ---
 

--- a/docs/architecture-decisions/ADR-068-provider-scoped-slot-addresses.md
+++ b/docs/architecture-decisions/ADR-068-provider-scoped-slot-addresses.md
@@ -1,7 +1,7 @@
 ---
 id: 0068
 title: Provider-scoped slot addresses
-status: Accepted
+status: Implemented
 date: 2026-07-11
 deciders: [sean]
 area: Runtime / slots / addressing / ownership
@@ -10,7 +10,8 @@ tags: [runtime, slots, addressing, ownership]
 relates-to: [57, 58, 66, 67]
 supersedes: [58]
 superseded-by: []
-implemented-by: []
+implemented-by:
+  - packages/contracts/src/slot-contract.ts
 verified-by: []
 long-form: true
 ---

--- a/docs/architecture-decisions/ADR-069-slot-grammar-single-source.md
+++ b/docs/architecture-decisions/ADR-069-slot-grammar-single-source.md
@@ -1,7 +1,7 @@
 ---
 id: 0069
 title: Slot grammar single-sourced in contracts
-status: Accepted
+status: Implemented
 date: 2026-07-12
 deciders: [sean]
 area: Contracts / DSL / runtime / packaging

--- a/docs/architecture-decisions/ADR-070-control-plane-owned-data-fetch-lifecycle.md
+++ b/docs/architecture-decisions/ADR-070-control-plane-owned-data-fetch-lifecycle.md
@@ -4,7 +4,7 @@ title: Experience-scoped federated supergraph (control-plane-composed data over 
 status: Accepted
 impl:
   stage: phased
-  refs: []
+  refs: ["#282", "#284", "#285", "#286", "#287", "#288"]
 date: 2026-07-19
 deciders: [sean]
 area: Runtime / control-plane / data / federation / lifecycle

--- a/docs/architecture-decisions/ADR-071-manifest-driven-client-dependencies.md
+++ b/docs/architecture-decisions/ADR-071-manifest-driven-client-dependencies.md
@@ -1,7 +1,7 @@
 ---
 id: 0071
 title: Manifest-Driven Client Dependencies and Federation Shared
-status: Accepted
+status: Implemented
 date: 2026-07-19
 deciders: [sean]
 area: Codegen / dependencies / module-federation

--- a/docs/architecture-decisions/ADR-072-slot-registration-api.md
+++ b/docs/architecture-decisions/ADR-072-slot-registration-api.md
@@ -1,7 +1,7 @@
 ---
 id: 0072
 title: "The sanctioned slot registration API: `DeclaredSlot`, typed by the manifest"
-status: Accepted
+status: Implemented
 date: 2026-07-25
 deciders: [sean]
 area: Codegen / slots / app-code API / typing

--- a/docs/architecture-decisions/ADR-073-slot-contract-in-contracts-design-time-validation.md
+++ b/docs/architecture-decisions/ADR-073-slot-contract-in-contracts-design-time-validation.md
@@ -1,7 +1,7 @@
 ---
 id: 0073
 title: Slot contract logic moves to `@seans-mfe/contracts`; placement targets become validatable
-status: Accepted
+status: Implemented
 date: 2026-07-25
 deciders: [sean]
 area: Contracts / CLI / slots / design-time validation

--- a/docs/architecture-decisions/ADR-075-adr-library-under-drift-control.md
+++ b/docs/architecture-decisions/ADR-075-adr-library-under-drift-control.md
@@ -1,7 +1,7 @@
 ---
 id: 0075
 title: The ADR Library Is Itself Under Drift Control
-status: Accepted
+status: Implemented
 date: 2026-07-25
 deciders: [sean]
 area: Governance / docs / tooling
@@ -115,8 +115,9 @@ Two new fields close the loop between a decision and the code that carries it:
 - **`verified-by`** — test names or npm-script gate names that demonstrate the
   decision holds.
 
-Both may be empty; a decision that is pure convention has nothing to point at,
-and forcing an invented path would be worse than an honest `[]`.
+A decision that is pure convention has nothing dedicated to point at, and forcing
+an invented path would be worse than an honest `[]` — §6 sets exactly when each
+field stops being optional.
 
 ### 4. Rules, not a linter
 
@@ -163,6 +164,62 @@ is rewritten.** Where a pre-reflow reference has no correct modern target, it is
 removed and the removal recorded in the README erratum table rather than
 repointed at a guess. After this pass the normal rule resumes, now with a gate
 that keeps it cheap to obey.
+
+### 6. The implementation lifecycle
+
+The five sections above make an ADR's state *representable*. They do not make the
+transitions *happen*, and the library's own history shows what that costs:
+ADR-029 and ADR-030 sat at `Proposed` while three files implemented and cited
+them, because nothing turns finished work into a status change except somebody
+remembering. Five more (ADR-045, 047, 048, 049 and their sibling ADR-046) were
+authored in a single day, marked `Proposed`, and never actioned — no owner, no
+issue, no expiry.
+
+So the states get a defined path and each transition gets an artifact:
+
+```
+Proposed ──ratify──> Accepted ──evidence──> Implemented
+   │                    │
+   └──> Withdrawn       └──> Deferred | Superseded
+```
+
+**`Proposed` is a proposal, not a plan.** Merging a `Proposed` ADR means "we
+agree with the direction" and nothing more. Code may not cite it — already
+enforced by `code-cites-ratified-adr` — so a `Proposed` decision cannot quietly
+acquire dependents.
+
+**`Accepted` means ratified, and outstanding work must be named.** An ADR that is
+`Accepted` with `impl.stage: deferred` has explicitly parked its implementation,
+and parked work without a tracking issue is how the 045–049 batch became
+permanent. Rule — `accepted-names-its-work`: `impl.stage: deferred` requires a
+non-empty `impl.refs`. `phased` does not, because incremental delivery is already
+in flight by definition.
+
+**`Implemented` is a claim the repo checks.** Rule —
+`implemented-claims-evidence`: `status: Implemented` requires a non-empty
+`implemented-by`. That is the tie between a decision and the code carrying it,
+and it is the field `implemented-by-exists` already validates, so the claim
+cannot rot as files move.
+
+`verified-by` is **not** required alongside it. Requiring a named gate for every
+implemented decision would force inventing one for ADR-004 ("Handler Array
+Support") and similar — a decision genuinely verified by the general suite rather
+than by a dedicated check. Instead, `verified-by` must *resolve* whenever it is
+present: an entry naming an npm script must exist in `package.json`, and an entry
+naming a path must exist on disk. Optional, but never decorative — the failure
+mode a declared-and-unchecked field always ends in.
+
+**The reverse direction is the one that would have caught ADR-029.** Rule —
+`finished-work-says-so`: an ADR that is `Accepted`, has no pending `impl.stage`,
+declares `implemented-by` paths that all exist, and is cited by source code, is
+finished — and is told to say so. The repo notices the transition instead of
+waiting to be told about it.
+
+Two things this deliberately does not do. It does not expire a `Proposed` ADR on
+a timer: staleness is a judgement about whether an argument still holds, and a
+date cannot make it. And it does not gate the `Proposed → Accepted` transition on
+anything mechanical — ratifying a decision is a human act, and the artifact it
+produces is the merge.
 
 ## Boundaries
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -262,17 +262,17 @@ All architecture decisions live in `docs/architecture-decisions/`. **Before impl
 | ADR-031 | Conditional Execution with Jexl Expression Engine | Lifecycle engine | Proposed |
 | ADR-032 | Inter-Hook Communication with TypeScript Code Generation | Lifecycle engine | Proposed |
 | ADR-033 | Two-headed giant — AI-native + human-legible DX | Developer model | Accepted |
-| ADR-034 | Pluggable bundler + framework via codegen variants | Codegen / polyglot | Accepted |
-| ADR-035 | Docker build orchestration via Turborepo task graph | Docker / CI | Accepted |
-| ADR-036 | Framework plugin system — `BaseFrameworkPlugin` + `loadFrameworkPlugin()` | Build / codegen / deploy | Accepted |
+| ADR-034 | Pluggable bundler + framework via codegen variants | Codegen / polyglot | Implemented |
+| ADR-035 | Docker build orchestration via Turborepo task graph | Docker / CI | Implemented |
+| ADR-036 | Framework plugin system — `BaseFrameworkPlugin` + `loadFrameworkPlugin()` | Build / codegen / deploy | Implemented |
 | ADR-037 | TDD-always development discipline | Process | Accepted |
 | ADR-038 | Conventional Commits and branch naming | Process | Accepted |
 | ADR-039 | Structured logger — no console.log in production code | CLI / logging | Accepted |
-| ADR-040 | Manifest-Declared Handler Sources | DSL / handlers / codegen | Accepted |
-| ADR-041 | BaseMFE Abstract Base Class & Platform Capability Contract | Runtime / base-class | Accepted |
-| ADR-042 | MFE Lifecycle State Machine | Runtime lifecycle | Accepted |
-| ADR-043 | Manifest-Driven Code Generation Pipeline | Codegen / DSL | Accepted |
-| ADR-044 | Production Container Hardening for Generated MFEs | Docker / deploy / security | Accepted |
+| ADR-040 | Manifest-Declared Handler Sources | DSL / handlers / codegen | Implemented |
+| ADR-041 | BaseMFE Abstract Base Class & Platform Capability Contract | Runtime / base-class | Implemented |
+| ADR-042 | MFE Lifecycle State Machine | Runtime lifecycle | Implemented |
+| ADR-043 | Manifest-Driven Code Generation Pipeline | Codegen / DSL | Implemented |
+| ADR-044 | Production Container Hardening for Generated MFEs | Docker / deploy / security | Implemented |
 | ADR-045 | Package Manager and Local Runtime Pinning | Tooling / package manager / runtime | Proposed |
 | ADR-046 | Environment Configuration and Secret Validation | Configuration / security | Proposed |
 | ADR-047 | CODEOWNERS and Review Routing for Architectural Surfaces | Governance / review | Proposed |
@@ -284,25 +284,25 @@ All architecture decisions live in `docs/architecture-decisions/`. **Before impl
 | ADR-053 | RemoteMFE.doQuery — Remove throw; BaseMFE.doQuery is sufficient | Runtime / query / BFF | Implemented |
 | ADR-054 | Control-Plane Message Protocol as a Shared Contract in @seans-mfe/contracts | Contracts / daemon / control-plane | Implemented |
 | ADR-055 | LayoutManager — Daemon-Driven Slot Composition for Generic Shells | Runtime / shell / layout / control-plane | Implemented |
-| ADR-056 | MFE Presentation Boundary and Host-Side Composition Providers (Polyglot VM Model) | Runtime / boundary / providers / polyglot | Accepted |
+| ADR-056 | MFE Presentation Boundary and Host-Side Composition Providers (Polyglot VM Model) | Runtime / boundary / providers / polyglot | Implemented |
 | ADR-057 | Virtualized Daemon Socket — Per-Slot Control-Plane Channels (DaemonChannel) | Runtime / control-plane / channels | Implemented |
 | ADR-058 | Slot-Provider MFEs — MFEs that Provide Slots for Other MFEs | Runtime / slots / composition | Implemented |
-| ADR-059 | BaseControlPlane — Abstract Base for All Control-Plane Implementations | Runtime / control-plane / abstract-base | Accepted |
-| ADR-060 | Contextualized VM Composition — Value-Injection, Slot-Scoped Self-Healing, Control-Plane Re-Resolution | Runtime / composition / resilience / context | Accepted |
-| ADR-061 | `@seans-mfe/dsl` and `@seans-mfe/codegen` as Packages; Framework Variant Injected, Not Resolved | Codegen / DSL / packaging | Accepted |
-| ADR-062 | `deploy` is Dev-Convenience Only; Production Deployment Returns as a Plugin-Resolved Target Axis | Deploy / plugins / scope | Accepted |
+| ADR-059 | BaseControlPlane — Abstract Base for All Control-Plane Implementations | Runtime / control-plane / abstract-base | Implemented |
+| ADR-060 | Contextualized VM Composition — Value-Injection, Slot-Scoped Self-Healing, Control-Plane Re-Resolution | Runtime / composition / resilience / context | Implemented |
+| ADR-061 | `@seans-mfe/dsl` and `@seans-mfe/codegen` as Packages; Framework Variant Injected, Not Resolved | Codegen / DSL / packaging | Implemented |
+| ADR-062 | `deploy` is Dev-Convenience Only; Production Deployment Returns as a Plugin-Resolved Target Axis | Deploy / plugins / scope | Accepted (impl deferred, #250) |
 | ADR-063 | API-Backend Generation is a Plugin Axis, Not a Wrapper Around One OSS Codegen | Codegen / API / plugins | Accepted (impl deferred, #251) |
 | ADR-064 | Runtime's Future is a Semver-Published Package, Not a Staged `dist/runtime` Folder | Runtime / packaging / distribution | Accepted (impl deferred, #252) |
 | ADR-065 | Generated API Reference with Drift Gate; DSL Manifest JSON Schema from the Zod Source of Truth | Docs / tooling / packaging | Accepted (impl phased, #264) |
-| ADR-066 | Stable Slot Addressing and Desired-State Placement — Backend Places Any Experience in Any Slot, Always | Runtime / slots / addressing / control-plane | Accepted |
-| ADR-067 | Manifest-Declared Slot Contract — Slots Declared in the DSL, Registration Code Generated from the Declaration | DSL / codegen / slots / contract | Accepted |
-| ADR-068 | Provider-Scoped Slot Addresses — Stable MFE ID + Declared Local Slot ID | Runtime / slots / addressing / ownership | Accepted |
-| ADR-069 | Slot Grammar Single-Sourced in Contracts | Contracts / DSL / runtime / packaging | Accepted |
-| ADR-070 | Experience-Scoped Federated Supergraph — Control-Plane-Composed Data over Participant MFE BFFs | Runtime / control-plane / data / federation / lifecycle | Accepted (impl phased) |
-| ADR-071 | Manifest-Driven Client Dependencies and Federation Shared | Codegen / dependencies / module-federation | Accepted |
-| ADR-072 | The Sanctioned Slot Registration API — `DeclaredSlot`, Typed by the Manifest | Codegen / slots / app-code API / typing | Accepted |
-| ADR-073 | Slot Contract Logic in Contracts; Placement Targets Become Validatable | Contracts / CLI / slots / design-time validation | Accepted |
-| ADR-075 | The ADR Library Is Itself Under Drift Control | Governance / docs / tooling | Accepted |
+| ADR-066 | Stable Slot Addressing and Desired-State Placement — Backend Places Any Experience in Any Slot, Always | Runtime / slots / addressing / control-plane | Implemented |
+| ADR-067 | Manifest-Declared Slot Contract — Slots Declared in the DSL, Registration Code Generated from the Declaration | DSL / codegen / slots / contract | Implemented |
+| ADR-068 | Provider-Scoped Slot Addresses — Stable MFE ID + Declared Local Slot ID | Runtime / slots / addressing / ownership | Implemented |
+| ADR-069 | Slot Grammar Single-Sourced in Contracts | Contracts / DSL / runtime / packaging | Implemented |
+| ADR-070 | Experience-Scoped Federated Supergraph — Control-Plane-Composed Data over Participant MFE BFFs | Runtime / control-plane / data / federation / lifecycle | Accepted (impl phased, #282, #284, #285, #286, #287, #288) |
+| ADR-071 | Manifest-Driven Client Dependencies and Federation Shared | Codegen / dependencies / module-federation | Implemented |
+| ADR-072 | The Sanctioned Slot Registration API — `DeclaredSlot`, Typed by the Manifest | Codegen / slots / app-code API / typing | Implemented |
+| ADR-073 | Slot Contract Logic in Contracts; Placement Targets Become Validatable | Contracts / CLI / slots / design-time validation | Implemented |
+| ADR-075 | The ADR Library Is Itself Under Drift Control | Governance / docs / tooling | Implemented |
 
 ---
 

--- a/packages/dsl/src/__tests__/adr-validation.test.ts
+++ b/packages/dsl/src/__tests__/adr-validation.test.ts
@@ -68,7 +68,10 @@ describe('validateAdrLibrary', () => {
     });
 
     it('accepts a well-formed ADR', () => {
-      const result = validateAdrLibrary({ documents: [adr(75, 'Fine')], parseFailures: [] });
+      const result = validateAdrLibrary({
+        documents: [adr(75, 'Fine', { 'implemented-by': ['CLAUDE.md'] })],
+        parseFailures: [],
+      });
       expect(result.ok).toBe(true);
       expect(result.issues).toHaveLength(0);
     });
@@ -199,8 +202,14 @@ describe('validateAdrLibrary', () => {
     it('accepts a supersession linked from both sides', () => {
       const result = validateAdrLibrary({
         documents: [
-          adr(68, 'Provider-scoped slot addresses', { supersedes: [58] }),
-          adr(58, 'Slot-provider MFEs', { 'superseded-by': [68] }),
+          adr(68, 'Provider-scoped slot addresses', {
+            supersedes: [58],
+            'implemented-by': ['CLAUDE.md'],
+          }),
+          adr(58, 'Slot-provider MFEs', {
+            'superseded-by': [68],
+            'implemented-by': ['CLAUDE.md'],
+          }),
         ],
         parseFailures: [],
       });
@@ -330,11 +339,197 @@ describe('validateAdrLibrary', () => {
 
     it('accepts a matching set', () => {
       const result = validateAdrLibrary({
-        documents: [adr(74, 'Registration is a build artifact')],
+        documents: [adr(74, 'Registration is a build artifact', { 'implemented-by': ['CLAUDE.md'] })],
         parseFailures: [],
         indexIds: [74],
       });
       expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('accepted-work-is-tracked (ADR-075 §6)', () => {
+    it('reports an Accepted ADR that neither names code nor schedules work', () => {
+      // The ADR-045..049 shape: ratified, then nothing ever pointed at it again.
+      const result = validateAdrLibrary({
+        documents: [adr(47, 'CODEOWNERS and review routing')],
+        parseFailures: [],
+      });
+      expect(rulesHit(result.issues)).toContain('accepted-work-is-tracked');
+    });
+
+    it('accepts an Accepted ADR whose code exists', () => {
+      const result = validateAdrLibrary({
+        documents: [adr(41, 'BaseMFE', { 'implemented-by': ['packages/runtime/src/base-mfe.ts'] })],
+        parseFailures: [],
+        existingPaths: new Set(['packages/runtime/src/base-mfe.ts']),
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts an Accepted ADR whose work is scheduled by an issue', () => {
+      const result = validateAdrLibrary({
+        documents: [adr(70, 'Supergraph', { impl: { stage: 'phased', refs: ['#282'] } })],
+        parseFailures: [],
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('reports parked work with no tracking issue', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(70, 'Federated supergraph', {
+            impl: { stage: 'deferred', refs: [] },
+            'implemented-by': ['packages/runtime/src/base-mfe.ts'],
+          }),
+        ],
+        existingPaths: new Set(['packages/runtime/src/base-mfe.ts']),
+        parseFailures: [],
+      });
+      expect(rulesHit(result.issues)).toContain('accepted-work-is-tracked');
+    });
+
+    it('accepts parked work that names its issue', () => {
+      const result = validateAdrLibrary({
+        documents: [adr(64, 'Runtime as a package', { impl: { stage: 'deferred', refs: ['#252'] } })],
+        parseFailures: [],
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('does not require refs for phased work already carried by code', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(25, 'Handler interface', {
+            impl: { stage: 'phased', refs: [] },
+            'implemented-by': ['packages/runtime/src/base-mfe.ts'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['packages/runtime/src/base-mfe.ts']),
+      });
+      expect(rulesHit(result.issues)).not.toContain('accepted-work-is-tracked');
+    });
+  });
+
+  describe('implemented-claims-evidence (ADR-075 §6)', () => {
+    it('reports an Implemented ADR that names no code', () => {
+      const result = validateAdrLibrary({
+        documents: [adr(53, 'RemoteMFE.doQuery', { status: 'Implemented' })],
+        parseFailures: [],
+      });
+      expect(rulesHit(result.issues)).toContain('implemented-claims-evidence');
+    });
+
+    it('accepts an Implemented ADR that names code', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(53, 'RemoteMFE.doQuery', {
+            status: 'Implemented',
+            'implemented-by': ['packages/runtime/src/remote-mfe.ts'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['packages/runtime/src/remote-mfe.ts']),
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('does not demand verified-by — some decisions have no dedicated gate', () => {
+      // ADR-004 "Handler Array Support" is verified by the general suite;
+      // forcing it to name a gate would mean inventing one.
+      const result = validateAdrLibrary({
+        documents: [
+          adr(4, 'Handler Array Support', {
+            status: 'Implemented',
+            'implemented-by': ['packages/dsl/src/schema.ts'],
+            'verified-by': [],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['packages/dsl/src/schema.ts']),
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('reports a verified-by entry that resolves to nothing', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(50, 'Dependency governance', {
+            status: 'Implemented',
+            'implemented-by': ['packages/codegen/src/unified-generator.ts'],
+            'verified-by': ['check:does-not-exist'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['packages/codegen/src/unified-generator.ts']),
+        scriptNames: new Set(['check:mfe-consistency', 'check:adr']),
+      });
+      expect(rulesHit(result.issues)).toContain('implemented-claims-evidence');
+    });
+
+    it('accepts a verified-by naming a real npm script', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(50, 'Dependency governance', {
+            status: 'Implemented',
+            'implemented-by': ['packages/codegen/src/unified-generator.ts'],
+            'verified-by': ['check:mfe-consistency'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['packages/codegen/src/unified-generator.ts']),
+        scriptNames: new Set(['check:mfe-consistency']),
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('finished-work-says-so (ADR-075 §6)', () => {
+    it('reports an Accepted ADR whose work is done and cited by code', () => {
+      // The ADR-029 failure inverted: code shipped, status never moved.
+      const result = validateAdrLibrary({
+        documents: [
+          adr(29, 'Timeout Protection', {
+            status: 'Accepted',
+            'implemented-by': ['packages/runtime/src/timeout-wrapper.ts'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['packages/runtime/src/timeout-wrapper.ts']),
+        sources: [{ path: 'packages/runtime/src/timeout-wrapper.ts', text: '// ADR-029' }],
+      });
+      expect(rulesHit(result.issues)).toContain('finished-work-says-so');
+    });
+
+    it('stays quiet while work is still phased', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(65, 'Generated API reference', {
+            status: 'Accepted',
+            impl: { stage: 'phased', refs: ['#264'] },
+            'implemented-by': ['scripts/generate-dsl-schema.ts'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['scripts/generate-dsl-schema.ts']),
+        sources: [{ path: 'x.ts', text: '// ADR-065' }],
+      });
+      expect(rulesHit(result.issues)).not.toContain('finished-work-says-so');
+    });
+
+    it('stays quiet when no code cites it — a ratified decision may just be policy', () => {
+      const result = validateAdrLibrary({
+        documents: [
+          adr(37, 'TDD always', {
+            status: 'Accepted',
+            'implemented-by': ['CLAUDE.md'],
+          }),
+        ],
+        parseFailures: [],
+        existingPaths: new Set(['CLAUDE.md']),
+        sources: [{ path: 'x.ts', text: 'unrelated' }],
+      });
+      expect(rulesHit(result.issues)).not.toContain('finished-work-says-so');
     });
   });
 

--- a/packages/dsl/src/adr-validation.ts
+++ b/packages/dsl/src/adr-validation.ts
@@ -36,7 +36,11 @@ export type AdrValidationRule =
   | 'supersession-bidirectional'
   | 'implemented-by-exists'
   | 'code-cites-ratified-adr'
-  | 'register-complete';
+  | 'register-complete'
+  // ADR-075 §6 — the implementation lifecycle.
+  | 'accepted-work-is-tracked'
+  | 'implemented-claims-evidence'
+  | 'finished-work-says-so';
 
 export interface AdrValidationIssue {
   rule: AdrValidationRule;
@@ -66,6 +70,11 @@ export interface AdrValidationInput {
   sources?: readonly SourceFile[];
   /** ADR ids listed in the generated index, for `register-complete`. */
   indexIds?: readonly (number | string)[];
+  /**
+   * npm script names from `package.json`, so a `verified-by` entry naming a gate
+   * can be resolved (ADR-075 §6). Omit to skip that half of the check.
+   */
+  scriptNames?: ReadonlySet<string>;
 }
 
 export interface AdrValidationResult {
@@ -358,6 +367,115 @@ export function validateAdrLibrary(input: AdrValidationInput): AdrValidationResu
         rule: 'register-complete',
         file: 'docs/spec.md',
         message: `the index lists ADR-${formatAdrId(id)}, which has no file`,
+      });
+    }
+  }
+
+  // ── ADR-075 §6: the implementation lifecycle ──────────────────────────────
+  //
+  // The rules above describe an ADR's state. These three move it: parked work
+  // has to name its issue, a claim of `Implemented` has to name its code, and
+  // finished work gets told to say so instead of waiting to be noticed. That
+  // last one is the ADR-029 failure inverted — three files implemented and
+  // cited it while the register still called it Proposed.
+
+  // 8. accepted-work-is-tracked — a ratified decision is either carried by code
+  //    or scheduled by an issue. "Neither" is how the ADR-045..049 batch became
+  //    permanent: five decisions authored in a day, with no owner and nothing
+  //    pointing at them ever again.
+  checked.push('accepted-work-is-tracked');
+  for (const document of input.documents) {
+    const fm = document.frontmatter;
+    if (fm.status !== 'Accepted') continue;
+
+    const carried = fm['implemented-by'].length > 0;
+    const scheduled = (fm.impl?.refs.length ?? 0) > 0;
+
+    if (!carried && !scheduled) {
+      issues.push({
+        rule: 'accepted-work-is-tracked',
+        file: document.path,
+        message:
+          'status is `Accepted` but nothing carries it and nothing is scheduled to — ' +
+          'name the code in implemented-by, or the issues in impl.refs',
+        expected: 'implemented-by: [<path>] or impl.refs: ["#NNN"]',
+      });
+      continue;
+    }
+
+    // Work explicitly parked still needs an issue even when something partial
+    // already carries it — otherwise the remainder has no owner.
+    if (fm.impl?.stage === 'deferred' && !scheduled) {
+      issues.push({
+        rule: 'accepted-work-is-tracked',
+        file: document.path,
+        message:
+          'impl.stage is `deferred` but impl.refs is empty — parked work needs a tracking issue',
+        expected: 'impl.refs: ["#NNN"]',
+      });
+    }
+  }
+
+  // 9. implemented-claims-evidence — `Implemented` must name the code that
+  //    carries it. `verified-by` stays optional but must resolve when present:
+  //    a declared field nothing checks is a field that rots.
+  checked.push('implemented-claims-evidence');
+  for (const document of input.documents) {
+    const fm = document.frontmatter;
+
+    if (fm.status === 'Implemented' && fm['implemented-by'].length === 0) {
+      issues.push({
+        rule: 'implemented-claims-evidence',
+        file: document.path,
+        message:
+          'status is `Implemented` but implemented-by is empty — name the code that carries it',
+        expected: 'implemented-by: [<path>]',
+      });
+    }
+
+    for (const claim of fm['verified-by']) {
+      const isScript = input.scriptNames?.has(claim);
+      const isPath = input.existingPaths?.has(claim);
+      // Skip when neither lookup is available rather than guessing.
+      if (input.scriptNames === undefined && input.existingPaths === undefined) break;
+      if (isScript || isPath) continue;
+      issues.push({
+        rule: 'implemented-claims-evidence',
+        file: document.path,
+        message:
+          `verified-by names "${claim}", which is neither an npm script nor a file in the repo`,
+        actual: claim,
+      });
+    }
+  }
+
+  // 10. finished-work-says-so — the transition nobody remembers to make.
+  if (input.sources) {
+    checked.push('finished-work-says-so');
+    const cited = new Set<number>();
+    for (const source of input.sources) {
+      for (const match of source.text.matchAll(ADR_MENTION)) {
+        cited.add(Number.parseInt(match[1], 10));
+      }
+    }
+
+    for (const document of input.documents) {
+      const fm = document.frontmatter;
+      const id = normalizeAdrId(fm.id);
+      if (fm.status !== 'Accepted' || fm.impl) continue;
+      if (fm['implemented-by'].length === 0) continue;
+      if (!cited.has(id)) continue;
+      if (input.existingPaths && fm['implemented-by'].some((p) => !input.existingPaths!.has(p))) {
+        continue; // implemented-by-exists owns that failure.
+      }
+      issues.push({
+        rule: 'finished-work-says-so',
+        file: document.path,
+        message:
+          'status is `Accepted` with no work outstanding, its implemented-by paths all exist, ' +
+          'and source code cites it — this looks Implemented',
+        expected: 'status: Implemented',
+        actual: 'Accepted',
       });
     }
   }

--- a/schemas/adr-status.json
+++ b/schemas/adr-status.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://seans-mfe.dev/schemas/adr:status.json",
+  "title": "adr:status",
+  "description": "Input/output contract for seans-mfe-tool adr:status",
+  "input": {
+    "type": "object",
+    "properties": {
+      "outstanding": {
+        "type": "boolean",
+        "default": false,
+        "description": "Only ratified work still to do"
+      },
+      "status": {
+        "type": "string",
+        "enum": [
+          "Proposed",
+          "Accepted",
+          "Implemented",
+          "Deferred",
+          "Superseded",
+          "Withdrawn"
+        ]
+      }
+    }
+  },
+  "output": {
+    "type": "object",
+    "required": [
+      "total",
+      "counts",
+      "outstanding",
+      "entries"
+    ],
+    "properties": {
+      "total": {
+        "type": "number"
+      },
+      "counts": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "number"
+        }
+      },
+      "outstanding": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/adrStatusEntry"
+        }
+      },
+      "entries": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/adrStatusEntry"
+        }
+      }
+    },
+    "definitions": {
+      "adrStatusEntry": {
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "status",
+          "area",
+          "refs",
+          "implementedBy"
+        ],
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "area": {
+            "type": "string"
+          },
+          "stage": {
+            "type": "string"
+          },
+          "refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "implementedBy": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  },
+  "errorCodes": [
+    0,
+    2,
+    64,
+    65,
+    66,
+    69,
+    70,
+    77,
+    124
+  ]
+}

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -196,6 +196,33 @@ const OUTPUT_SCHEMAS: Record<string, object> = {
     },
     additionalProperties: false,
   },
+  'adr:status': {
+    type: 'object',
+    required: ['total', 'counts', 'outstanding', 'entries'],
+    properties: {
+      total:  { type: 'number' },
+      counts: { type: 'object', additionalProperties: { type: 'number' } },
+      outstanding: { type: 'array', items: { $ref: '#/definitions/adrStatusEntry' } },
+      entries:     { type: 'array', items: { $ref: '#/definitions/adrStatusEntry' } },
+    },
+    definitions: {
+      adrStatusEntry: {
+        type: 'object',
+        required: ['id', 'title', 'status', 'area', 'refs', 'implementedBy'],
+        properties: {
+          id:            { type: 'number' },
+          title:         { type: 'string' },
+          status:        { type: 'string' },
+          area:          { type: 'string' },
+          stage:         { type: 'string' },
+          refs:          { type: 'array', items: { type: 'string' } },
+          implementedBy: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    },
+    additionalProperties: false,
+  },
   'adr:validate': {
     type: 'object',
     required: ['adrs', 'ok', 'checked', 'issues'],
@@ -272,6 +299,16 @@ const INPUT_SCHEMAS: Record<string, object> = {
     properties: {
       dir:       { type: 'string', description: 'MFE directory to validate (default: cwd)' },
       typecheck: { type: 'boolean', default: false, description: 'Also run `tsc --noEmit`' },
+    },
+  },
+  'adr:status': {
+    type: 'object',
+    properties: {
+      outstanding: { type: 'boolean', default: false, description: 'Only ratified work still to do' },
+      status: {
+        type: 'string',
+        enum: ['Proposed', 'Accepted', 'Implemented', 'Deferred', 'Superseded', 'Withdrawn'],
+      },
     },
   },
   'adr:validate': {

--- a/src/commands/adr/status.ts
+++ b/src/commands/adr/status.ts
@@ -1,0 +1,186 @@
+/**
+ * adr:status — what the decision record is actually in the middle of (ADR-075 §6).
+ *
+ * The closed status vocabulary exists so the register can answer questions
+ * instead of being read cover to cover. This is the command that asks them:
+ * what is still only proposed, what is ratified with work outstanding and which
+ * issues track it, and what is finished.
+ *
+ * Before ADR-075 none of this was answerable — the status column held thirteen
+ * distinct strings for 74 records, and "Accepted (impl deferred, #252)" was a
+ * sentence rather than a field.
+ */
+
+import * as path from 'path';
+import { Flags } from '@oclif/core';
+import chalk = require('chalk');
+import * as fs from 'fs-extra';
+import { BaseCommand } from '../../oclif/BaseCommand';
+import { ValidationError } from '@seans-mfe/contracts';
+import {
+  parseAdrDocument,
+  formatAdrId,
+  normalizeAdrId,
+  type AdrStatus as AdrStatusValue,
+} from '@seans-mfe/dsl';
+
+const ADR_DIR = path.join('docs', 'architecture-decisions');
+
+/** Display order — the lifecycle path, not alphabetical. */
+const STATUS_ORDER: readonly AdrStatusValue[] = [
+  'Proposed',
+  'Accepted',
+  'Implemented',
+  'Deferred',
+  'Superseded',
+  'Withdrawn',
+];
+
+export interface AdrStatusEntry {
+  id: number;
+  title: string;
+  status: AdrStatusValue;
+  area: string;
+  /** `phased` / `deferred` when work is outstanding. */
+  stage?: string;
+  /** Issues tracking the outstanding work. */
+  refs: string[];
+  implementedBy: string[];
+}
+
+export interface AdrStatusResult {
+  total: number;
+  counts: Record<string, number>;
+  /** Ratified but not finished — the actionable list. */
+  outstanding: AdrStatusEntry[];
+  entries: AdrStatusEntry[];
+}
+
+export interface AdrStatusOptions {
+  root?: string;
+  /** Limit output to one status. */
+  status?: string;
+  /** Show only ratified-but-unfinished decisions. */
+  outstandingOnly?: boolean;
+}
+
+export async function adrStatusCommand(opts: AdrStatusOptions = {}): Promise<AdrStatusResult> {
+  const root = path.resolve(opts.root ?? process.cwd());
+  const dir = path.join(root, ADR_DIR);
+  if (!(await fs.pathExists(dir))) {
+    throw new ValidationError(`No ADR directory at ${ADR_DIR}`, 'adr-dir', 'required');
+  }
+
+  const entries: AdrStatusEntry[] = [];
+  const unparsed: string[] = [];
+
+  for (const name of (await fs.readdir(dir)).sort()) {
+    if (!/^ADR-\d+.*\.md$/.test(name)) continue;
+    const parsed = parseAdrDocument(name, await fs.readFile(path.join(dir, name), 'utf8'));
+    if (parsed.status !== 'ok') {
+      unparsed.push(name);
+      continue;
+    }
+    const fm = parsed.document.frontmatter;
+    entries.push({
+      id: normalizeAdrId(fm.id),
+      title: fm.title,
+      status: fm.status,
+      area: fm.area ?? '—',
+      stage: fm.impl?.stage,
+      refs: fm.impl?.refs ?? [],
+      implementedBy: fm['implemented-by'],
+    });
+  }
+
+  entries.sort((a, b) => a.id - b.id);
+
+  const counts: Record<string, number> = {};
+  for (const entry of entries) counts[entry.status] = (counts[entry.status] ?? 0) + 1;
+
+  // "Outstanding" = ratified, with work the register knows is not done.
+  const outstanding = entries.filter(
+    (e) => e.status === 'Accepted' && (e.stage !== undefined || e.implementedBy.length === 0)
+  );
+
+  const wanted = opts.outstandingOnly
+    ? outstanding
+    : opts.status
+      ? entries.filter((e) => e.status.toLowerCase() === opts.status!.toLowerCase())
+      : entries;
+
+  console.log('');
+  if (!opts.status && !opts.outstandingOnly) {
+    const summary = STATUS_ORDER.filter((s) => counts[s])
+      .map((s) => `${chalk.bold(String(counts[s]))} ${s}`)
+      .join(chalk.gray('  ·  '));
+    console.log(`  ${summary}     ${chalk.gray(`(${entries.length} ADRs)`)}`);
+    if (unparsed.length > 0) {
+      console.log(chalk.yellow(`  ${unparsed.length} unparsed — run \`npm run check:adr\``));
+    }
+    console.log('');
+  }
+
+  const shown = opts.outstandingOnly ? outstanding : wanted;
+  if (shown.length === 0) {
+    console.log(chalk.green('  nothing outstanding.\n'));
+    return { total: entries.length, counts, outstanding, entries };
+  }
+
+  if (opts.outstandingOnly) {
+    console.log(chalk.bold('  Ratified, work outstanding\n'));
+  }
+
+  for (const entry of shown) {
+    // Work in flight with no issue behind it is the thing worth seeing: the
+    // gate only *fails* on parked work (ADR-075 §6), because phased delivery is
+    // by definition already moving — but "moving" with nothing to read is how a
+    // decision quietly stops moving.
+    const tracked =
+      entry.refs.length > 0
+        ? chalk.cyan(entry.refs.join(' '))
+        : entry.stage !== undefined
+          ? chalk.yellow('no tracking issue — file one to guide the remaining work')
+          : entry.implementedBy.length > 0
+            ? chalk.gray('carried by code')
+            : chalk.red('untracked');
+    const stage = entry.stage ? chalk.gray(` [${entry.stage}]`) : '';
+    console.log(
+      `  ADR-${formatAdrId(entry.id)}  ${entry.status.padEnd(12)}${stage} ${entry.title.slice(0, 58)}`
+    );
+    if (opts.outstandingOnly || entry.status === 'Accepted') {
+      console.log(`             ${tracked}`);
+    }
+  }
+  console.log('');
+
+  return { total: entries.length, counts, outstanding, entries };
+}
+
+export default class AdrStatus extends BaseCommand<AdrStatusResult> {
+  static description = 'Show ADR lifecycle state — what is proposed, outstanding, or done (ADR-075)';
+
+  static examples = [
+    '$ seans-mfe-tool adr:status',
+    '$ seans-mfe-tool adr:status --outstanding',
+    '$ seans-mfe-tool adr:status --status Proposed',
+    '$ seans-mfe-tool adr:status --json',
+  ];
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    outstanding: Flags.boolean({
+      description: 'Only decisions that are ratified with work still to do',
+      default: false,
+    }),
+    status: Flags.string({
+      description: 'Filter to one status',
+      options: [...STATUS_ORDER],
+    }),
+  };
+
+  protected async runCommand(): Promise<AdrStatusResult> {
+    const { flags } = await this.parse(AdrStatus);
+    return adrStatusCommand({ status: flags.status, outstandingOnly: flags.outstanding });
+  }
+}

--- a/src/commands/adr/validate.ts
+++ b/src/commands/adr/validate.ts
@@ -105,19 +105,33 @@ async function collectSources(root: string, roots: string[]): Promise<SourceFile
 /**
  * Resolve only the paths ADRs actually declare.
  *
- * Cheaper and equivalent to walking the repo: the rule asks whether each
+ * Cheaper and equivalent to walking the repo: the rules ask whether each
  * declared path exists, so the set need only contain the ones that do.
+ *
+ * Both fields contribute. `verified-by` may name either an npm script or a
+ * path, and resolving only `implemented-by` made every path-shaped
+ * `verified-by` entry look unresolvable.
  */
 async function resolveDeclaredPaths(
   root: string,
   documents: readonly AdrDocument[]
 ): Promise<Set<string>> {
-  const declared = new Set(documents.flatMap((d) => d.frontmatter['implemented-by']));
+  const declared = new Set(
+    documents.flatMap((d) => [...d.frontmatter['implemented-by'], ...d.frontmatter['verified-by']])
+  );
   const existing = new Set<string>();
   for (const relative of declared) {
     if (await fs.pathExists(path.join(root, relative))) existing.add(relative);
   }
   return existing;
+}
+
+/** npm script names, so `verified-by` can name a gate and be checked (ADR-075 §6). */
+async function readScriptNames(root: string): Promise<Set<string>> {
+  const pkgPath = path.join(root, 'package.json');
+  if (!(await fs.pathExists(pkgPath))) return new Set();
+  const pkg = (await fs.readJson(pkgPath)) as { scripts?: Record<string, string> };
+  return new Set(Object.keys(pkg.scripts ?? {}));
 }
 
 /** ADR ids listed in the `docs/spec.md` index table. */
@@ -145,6 +159,7 @@ export async function adrValidateCommand(
     existingPaths: await resolveDeclaredPaths(root, documents),
     sources: await collectSources(root, sourceRoots),
     indexIds: await readIndexIds(root),
+    scriptNames: await readScriptNames(root),
   });
 
   const result: AdrValidateResult = {


### PR DESCRIPTION
## What this is

PR 4 of 4, stacked on #313. §1–5 of ADR-075 made an ADR's state *representable*. They did not make the transitions *happen* — and the library's own history is the argument for why that matters:

- **ADR-029 and ADR-030** sat at `Proposed` while three files implemented and cited them. Nothing turns finished work into a status change except somebody remembering.
- **ADR-045, 047, 048, 049** were ratified in a single day and never actioned. No owner, no issue, nothing pointing at them again.

Amends **ADR-075 with §6** (still unmerged, so amending beats a second ADR on one idea) defining `Proposed → Accepted → Implemented`, and gives each transition an artifact the repo checks.

## The three rules

**`accepted-work-is-tracked`** — *this is your "covered by gh issues" ask.* An `Accepted` ADR must either name the code that carries it (`implemented-by`) or the issues that will (`impl.refs`). **"Neither" is the defect** — it's exactly the 045–049 shape. Work explicitly parked (`impl.stage: deferred`) always needs an issue, even when something partial already exists, because otherwise the remainder has no owner.

**`implemented-claims-evidence`** — `Implemented` requires a non-empty `implemented-by`. That's the tie between decision and code, and `implemented-by-exists` already keeps it from rotting as files move.

I **did not** make `verified-by` mandatory alongside it, which is a change from what I proposed. Forcing a named gate for ADR-004 "Handler Array Support" would mean inventing one — it's genuinely verified by the general suite. Instead `verified-by` must *resolve* whenever present: an npm script that exists in `package.json`, or a path on disk. Optional, never decorative.

**`finished-work-says-so`** — the ADR-029 failure inverted. An `Accepted` ADR with no work outstanding, whose `implemented-by` paths all exist, that source code cites, is finished — and gets told to say so. The repo notices the transition instead of waiting to be told.

Two things §6 deliberately does **not** do: expire a `Proposed` ADR on a timer (staleness is a judgement about whether an argument still holds; a date can't make it), and gate `Proposed → Accepted` on anything mechanical (ratifying is a human act; the artifact is the merge).

## `adr:status` — the payoff that was never collected

```
$ seans-mfe-tool adr:status
  9 Proposed  ·  21 Accepted  ·  43 Implemented  ·  1 Deferred     (74 ADRs)

$ seans-mfe-tool adr:status --outstanding
  Ratified, work outstanding

  ADR-025  Accepted  [phased]  Platform Handler Interface & Execution Model
             no tracking issue — file one to guide the remaining work
  ADR-026  Accepted  [phased]  Load Capability — Atomic Operation Design
             no tracking issue — file one to guide the remaining work
  ADR-062  Accepted  [deferred] `deploy` is a dev-convenience wrapper…       #250
  ADR-063  Accepted  [deferred] API-backend generation is a plugin axis…     #251
  ADR-064  Accepted  [deferred] The runtime's future is a semver package…    #252
  ADR-065  Accepted  [phased]  Generated API Reference with Drift Gate       #264
  ADR-070  Accepted  [phased]  Experience-scoped federated supergraph
             #282 #284 #285 #286 #287 #288
```

Seven ratified decisions with work to do; five naming real open issues. That question was unanswerable before — the status column held 13 distinct strings and `Accepted (impl deferred, #252)` was a sentence, not a field.

## What the rules found when I ran them

- **50 ADRs gained `implemented-by`/`verified-by`.** Every path is verified to exist *before* being written — the backfill refused to run twice on paths that turned out not to be there (`.eslintrc.json`, a wrong ADR-044 target). Claiming evidence that doesn't exist would be worse than the empty field it replaces.
- **20 ADRs reconciled `Accepted` → `Implemented`**: 034, 035, 036, 040–044, 056, 059, 060, 061, 066–069, 071, 072, 073, 075. `CLAUDE.md`'s own status table already called most of them done; the register didn't. This is `finished-work-says-so` paying for itself on first run.
- **ADR-062 had no `impl` block at all** — now tracks #250.

## Two bugs of mine the rules surfaced

1. **`verified-by` paths were never resolved.** Only `implemented-by` fed the existence set, so every path-shaped `verified-by` entry reported as unresolvable — including the ones I'd just written correctly.
2. **ADR-025 and ADR-026 are `phased` with no tracking issue.** The gate does *not* fail on that (phased work is in flight by definition), but letting it read as healthy was wrong. `adr:status` now prints it in yellow. **These two need issues filed** — I didn't invent numbers for them; say the word and I'll open them.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | 0 errors |
| `npm run typecheck` | clean |
| `npx jest` (CI exclusions) | **115 suites / 2131 tests** |
| `npm run build` + `build:schemas:check` | clean, incl. new `schemas/adr-status.json` |
| `npm run check:adr` | 11 rules, **6 findings — all ADR-074 cross-branch** |
| `./bin/run.js adr:status --json` | one envelope line, `ok:true`, 7 outstanding |

The 46 unit tests include a fixture per lifecycle case, each drawn from the real failure it models.

## Merge order

**#311 → #312 → #313 → this.** The 6 remaining findings are ADR-075 citing ADR-074, which lives on #311. They clear when it merges.

Note PR 3 (index generation) has **not** been written yet — you asked for the lifecycle as PR 4, so it's still queued. It stacks cleanly after this.

Refs ADR-075.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kam2PA1WzFarjVscA3JWYm)_