### PR TITLE
chore: clean up all ESLint warnings — 276 → 0 (#208)

### DIFF
--- a/packages/bff-plugin/src/commands/bff/__tests__/bff-workflow.test.ts
+++ b/packages/bff-plugin/src/commands/bff/__tests__/bff-workflow.test.ts
@@ -60,10 +60,6 @@ interface BffManifest {
   [key: string]: unknown;
 }
 
-async function readYaml<T = unknown>(filePath: string): Promise<T> {
-  return yaml.load(await fs.readFile(filePath, 'utf8')) as T;
-}
-
 async function writeYaml(filePath: string, value: unknown): Promise<void> {
   await fs.writeFile(filePath, yaml.dump(value), 'utf8');
 }

--- a/packages/bff-plugin/src/commands/bff/build.ts
+++ b/packages/bff-plugin/src/commands/bff/build.ts
@@ -47,8 +47,9 @@ export async function bffBuildCommand(
             stdio: 'inherit',
           });
           execSync('npx mesh build', { cwd: targetDir, stdio: 'inherit' });
-        } catch (installErr) {
-          throw new NetworkError('Failed to install or run @graphql-mesh/cli', 1);
+        } catch (installErr: unknown) {
+          const detail = installErr instanceof Error ? installErr.message : String(installErr);
+          throw new NetworkError(`Failed to install or run @graphql-mesh/cli: ${detail}`, 1);
         }
       } else {
         throw meshError;

--- a/packages/bff-plugin/src/utils/templateProcessor.js
+++ b/packages/bff-plugin/src/utils/templateProcessor.js
@@ -42,7 +42,7 @@ async function processTemplates(targetDir, vars) {
   let files;
   try {
     files = await fs.readdir(targetDir);
-  } catch (e) {
+  } catch {
     await tryFallback();
     return;
   }

--- a/packages/codegen/src/unified-generator.ts
+++ b/packages/codegen/src/unified-generator.ts
@@ -1118,7 +1118,6 @@ async function renderFiles(
     }
   }
   if (preservedCapabilities.length > 0) {
-    // eslint-disable-next-line no-console
     console.log(
       `Preserved (already implemented): ${preservedCapabilities.join(', ')}`,
     );
@@ -1332,7 +1331,6 @@ async function renderFiles(
       });
     } else {
       // Diagnostic: warn if template missing
-      // eslint-disable-next-line no-console
       console.warn(
         `[unified-generator] WARNING: Missing template for ${tpl.name}: ${templatePath}`
       );
@@ -1358,7 +1356,6 @@ async function renderFiles(
           overwrite,
         });
       } else {
-        // eslint-disable-next-line no-console
         console.warn(`[unified-generator] WARNING: Missing template for ${out}: ${templatePath}`);
       }
     }
@@ -1375,7 +1372,6 @@ async function renderFiles(
       });
     } else {
       // Diagnostic: warn if App.tsx template missing
-      // eslint-disable-next-line no-console
       console.warn(`[unified-generator] WARNING: Missing template for App.tsx: ${appTemplatePath}`);
     }
 
@@ -1409,7 +1405,6 @@ async function renderFiles(
       });
     } else {
       // Diagnostic: warn if index.tsx template missing
-      // eslint-disable-next-line no-console
       console.warn(
         `[unified-generator] WARNING: Missing template for index.tsx: ${indexTemplatePath}`
       );
@@ -1449,7 +1444,6 @@ async function renderFiles(
       }
     }
     if (!slotsEmitted) {
-      // eslint-disable-next-line no-console
       console.warn(
         `[unified-generator] WARNING: manifest declares providesSlots but template variant ` +
           `"${templateVariant}" ships no slots template (looked for ${slotsTemplateCandidates.join(', ')} in ${templateDir})`
@@ -1470,7 +1464,6 @@ async function renderFiles(
       overwrite: true,
     });
   } else {
-    // eslint-disable-next-line no-console
     console.warn(
       `[unified-generator] WARNING: Missing template for public/index.html: ${indexHtmlTemplatePath}`
     );
@@ -1489,7 +1482,6 @@ async function renderFiles(
       overwrite: true,
     });
   } else {
-    // eslint-disable-next-line no-console
     console.warn(
       `[unified-generator] WARNING: Missing template for public/demo.html: ${demoHtmlTemplatePath}`
     );
@@ -1503,7 +1495,6 @@ async function renderFiles(
       overwrite: true,
     });
   } else {
-    // eslint-disable-next-line no-console
     console.warn(
       `[unified-generator] WARNING: Missing template for public/favicon.ico: ${faviconTemplatePath}`
     );

--- a/packages/contracts/src/__tests__/registry-slot-pin.test.ts
+++ b/packages/contracts/src/__tests__/registry-slot-pin.test.ts
@@ -14,7 +14,6 @@
 import * as path from 'path';
 import { createSlotAddressRegistry } from '../slot-contract';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const registryModulePath = path.join(
   __dirname,
   '../../../../examples/meridian-station/control-plane/registry/slot-target.js'
@@ -27,7 +26,6 @@ type ValidateSlotTarget = (
 ) => RegistryProblem;
 
 /** The registry copy is ESM-only JS; jest transpiles it on require. */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { validateSlotTarget } = require(registryModulePath) as {
   validateSlotTarget: ValidateSlotTarget;
 };

--- a/packages/dsl/src/__tests__/parser.test.ts
+++ b/packages/dsl/src/__tests__/parser.test.ts
@@ -3,7 +3,6 @@
  * Following TDD principles - testing parser functionality
  */
 
-import * as path from 'path';
 import * as fs from 'fs-extra';
 import {
   parseYAML,

--- a/packages/dsl/src/__tests__/schema.lchook.test.ts
+++ b/packages/dsl/src/__tests__/schema.lchook.test.ts
@@ -1,5 +1,4 @@
 import { LifecycleHookSchema, PLATFORM_WRAPPER_METHODS } from '../schema';
-import { z } from 'zod';
 
 describe('LifecycleHookSchema handler reference validation', () => {
   it('accepts valid user-defined handler string', () => {

--- a/packages/dsl/src/__tests__/type-system-acceptance.test.ts
+++ b/packages/dsl/src/__tests__/type-system-acceptance.test.ts
@@ -3,8 +3,6 @@
  * REQ-047
  */
 
-import { jest } from '@jest/globals';
-
 const { parseType, toGraphQLType, toTypeScriptType, toPythonType, generateZodSchema, validateValue } = require('../type-system');
 
 describe('Type System Acceptance (REQ-047)', () => {

--- a/packages/dsl/src/__tests__/type-system-acceptance.test.ts
+++ b/packages/dsl/src/__tests__/type-system-acceptance.test.ts
@@ -5,7 +5,6 @@
 
 import { jest } from '@jest/globals';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { parseType, toGraphQLType, toTypeScriptType, toPythonType, generateZodSchema, validateValue } = require('../type-system');
 
 describe('Type System Acceptance (REQ-047)', () => {

--- a/packages/dsl/src/__tests__/type-system.test.ts
+++ b/packages/dsl/src/__tests__/type-system.test.ts
@@ -12,7 +12,6 @@ import {
   toPythonType,
   generateZodSchema,
   validateValue,
-  type ParsedType,
   type TypeConstraints
 } from '../type-system';
 

--- a/packages/dsl/src/__tests__/type-system.unit.test.ts
+++ b/packages/dsl/src/__tests__/type-system.unit.test.ts
@@ -2,7 +2,6 @@
  * Type System Unit Tests for coverage
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { parseType, isPrimitive, isSpecialized, toGraphQLType, toTypeScriptType, toPythonType, generateZodSchema, validateValue } = require('../type-system');
 
 describe('type-system primitives and specialized', () => {

--- a/packages/dsl/src/parser.ts
+++ b/packages/dsl/src/parser.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import type { DSLManifest, ValidationResult } from './schema';
 import { KNOWN_FRAMEWORKS, KNOWN_BUNDLERS } from './schema';
-import { validateManifest, validateFull } from './validator';
+import { validateFull } from './validator';
 
 // =============================================================================
 // Constants

--- a/packages/dsl/src/type-system.ts
+++ b/packages/dsl/src/type-system.ts
@@ -6,8 +6,6 @@
  * Supports GraphQL nullability conventions: nullable by default, ! for required.
  */
 
-import { z } from 'zod';
-
 // =============================================================================
 // Type Definitions
 // =============================================================================

--- a/packages/framework-angular/src/runtime/__tests__/declared-slot.directive.test.ts
+++ b/packages/framework-angular/src/runtime/__tests__/declared-slot.directive.test.ts
@@ -25,7 +25,6 @@ jest.mock('@angular/core', () => ({
   },
 }));
 
-// eslint-disable-next-line import/first
 import { DeclaredSlotDirective, type SlotContractLike } from '../declared-slot.directive';
 
 /** Minimal contract fake: 'main' and 'info' are declared, everything else is not. */

--- a/packages/oclif-base/src/BaseCommand.ts
+++ b/packages/oclif-base/src/BaseCommand.ts
@@ -60,12 +60,17 @@ export abstract class BaseCommand<T = unknown> extends Command {
           correlationId,
         });
         await new Promise<void>((resolve) => writeJsonLine(JSON.stringify(envelope), resolve));
+        // The --json envelope contract (ADR-018) requires a specific sysexits
+        // code; oclif's default error handler would pick its own. This is the
+        // one place responsible for that translation.
+        // eslint-disable-next-line no-process-exit
         process.exit(EXIT_CODES.ok);
       }
     } catch (err) {
       if (jsonMode) {
         const envelope = formatError(err, correlationId, startTime);
         await new Promise<void>((resolve) => writeJsonLine(JSON.stringify(envelope), resolve));
+        // eslint-disable-next-line no-process-exit -- same envelope exit-code contract as above
         process.exit(exitCodeFor(envelope.error?.type ?? 'unknown'));
       }
       throw err;

--- a/packages/oclif-base/src/json-output.ts
+++ b/packages/oclif-base/src/json-output.ts
@@ -76,7 +76,6 @@ export function blockInteractivePrompts(): void {
   Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true, configurable: true });
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const inquirer = require('inquirer') as { prompt: (...args: unknown[]) => Promise<unknown> };
     if (inquirer && typeof inquirer.prompt === 'function') {
       const originalPrompt = inquirer.prompt.bind(inquirer);

--- a/packages/runtime/src/__tests__/base-mfe.coverage.test.ts
+++ b/packages/runtime/src/__tests__/base-mfe.coverage.test.ts
@@ -6,18 +6,18 @@ class TestMFE extends BaseMFE {
   constructor(manifest: any, deps?: any) {
     super(manifest, deps);
   }
-  protected async doLoad(context: any): Promise<{ status: "loaded"; timestamp: Date }> {
+  protected async doLoad(_context: any): Promise<{ status: "loaded"; timestamp: Date }> {
     return { status: "loaded", timestamp: new Date() };
   }
-  protected async doRender(context: any): Promise<{ status: "rendered"; element: null; timestamp: Date }> {
+  protected async doRender(_context: any): Promise<{ status: "rendered"; element: null; timestamp: Date }> {
     return { status: "rendered", element: null, timestamp: new Date() };
   }
-  protected async doRefresh(context: any): Promise<void> { return; }
-  protected async doAuthorizeAccess(context: any): Promise<boolean> { return true; }
-  protected async doHealth(context: any): Promise<{ status: "healthy"; checks: any[]; timestamp: Date }> {
+  protected async doRefresh(_context: any): Promise<void> { return; }
+  protected async doAuthorizeAccess(_context: any): Promise<boolean> { return true; }
+  protected async doHealth(_context: any): Promise<{ status: "healthy"; checks: any[]; timestamp: Date }> {
     return { status: "healthy", checks: [], timestamp: new Date() };
   }
-  protected async doDescribe(context: any): Promise<{ name: string; version: string; type: "tool"; capabilities: any[]; manifest: { name: string; version: string; type: "tool"; language: "javascript"; capabilities: any[] } }> {
+  protected async doDescribe(_context: any): Promise<{ name: string; version: string; type: "tool"; capabilities: any[]; manifest: { name: string; version: string; type: "tool"; language: "javascript"; capabilities: any[] } }> {
     return {
       name: "test",
       version: "1.0",
@@ -32,13 +32,13 @@ class TestMFE extends BaseMFE {
       }
     };
   }
-  protected async doSchema(context: any): Promise<{ schema: string; format: "json" }> {
+  protected async doSchema(_context: any): Promise<{ schema: string; format: "json" }> {
     return { schema: "{}", format: "json" };
   }
-  protected async doQuery(context: any): Promise<{ data: string }> {
+  protected async doQuery(_context: any): Promise<{ data: string }> {
     return { data: "ok" };
   }
-  protected async doEmit(context: any): Promise<{ emitted: boolean }> {
+  protected async doEmit(_context: any): Promise<{ emitted: boolean }> {
     return { emitted: true };
   }
   protected async doUpdateControlPlaneState(context: any): Promise<{ acknowledged: boolean; correlationId: string }> {
@@ -209,7 +209,7 @@ it('should call errorHandler if DI errorHandler provided and state is invalid', 
   (mfeError as any).state = 'loading';
   try {
     (mfeError as any).assertState('ready');
-  } catch (e) {
+  } catch {
     // expected
   }
   expect(errorHandled).toBe(true);
@@ -221,18 +221,18 @@ describe('BaseMFE Full Coverage', () => {
     constructor(manifest: any, deps?: any) {
       super(manifest, deps);
     }
-    protected async doLoad(context: any): Promise<{ status: "loaded"; timestamp: Date }> {
+    protected async doLoad(_context: any): Promise<{ status: "loaded"; timestamp: Date }> {
       return { status: "loaded", timestamp: new Date() };
     }
-    protected async doRender(context: any): Promise<{ status: "rendered"; element: null; timestamp: Date }> {
+    protected async doRender(_context: any): Promise<{ status: "rendered"; element: null; timestamp: Date }> {
       return { status: "rendered", element: null, timestamp: new Date() };
     }
-    protected async doRefresh(context: any): Promise<void> { return; }
-    protected async doAuthorizeAccess(context: any): Promise<boolean> { return true; }
-    protected async doHealth(context: any): Promise<{ status: "healthy"; checks: any[]; timestamp: Date }> {
+    protected async doRefresh(_context: any): Promise<void> { return; }
+    protected async doAuthorizeAccess(_context: any): Promise<boolean> { return true; }
+    protected async doHealth(_context: any): Promise<{ status: "healthy"; checks: any[]; timestamp: Date }> {
       return { status: "healthy", checks: [], timestamp: new Date() };
     }
-    protected async doDescribe(context: any): Promise<{ name: string; version: string; type: "tool"; capabilities: any[]; manifest: { name: string; version: string; type: "tool"; language: "javascript"; capabilities: any[] } }> {
+    protected async doDescribe(_context: any): Promise<{ name: string; version: string; type: "tool"; capabilities: any[]; manifest: { name: string; version: string; type: "tool"; language: "javascript"; capabilities: any[] } }> {
       return {
         name: "test",
         version: "1.0",
@@ -247,13 +247,13 @@ describe('BaseMFE Full Coverage', () => {
         }
       };
     }
-    protected async doSchema(context: any): Promise<{ schema: string; format: "json" }> {
+    protected async doSchema(_context: any): Promise<{ schema: string; format: "json" }> {
       return { schema: "{}", format: "json" };
     }
-    protected async doQuery(context: any): Promise<{ data: string }> {
+    protected async doQuery(_context: any): Promise<{ data: string }> {
       return { data: "ok" };
     }
-    protected async doEmit(context: any): Promise<{ emitted: boolean }> {
+    protected async doEmit(_context: any): Promise<{ emitted: boolean }> {
       return { emitted: true };
     }
     async customA(context: any) { context.calledA = true; }

--- a/packages/runtime/src/__tests__/base-mfe.unit.test.ts
+++ b/packages/runtime/src/__tests__/base-mfe.unit.test.ts
@@ -5,7 +5,7 @@
 import { BaseMFE } from '../base-mfe';
 
 class TestMFE extends BaseMFE {
-    async fail(context: any) {
+    async fail(_context: any) {
       console.log('fail method called');
       throw new Error('boom');
     }
@@ -15,7 +15,7 @@ class TestMFE extends BaseMFE {
     super(manifest);
     this.handlers = {
       'custom.load': async (ctx: any) => { console.log('custom.load handler called'); return { status: 'loaded', timestamp: new Date(), context: ctx }; },
-      'custom.query': async (ctx: any) => { console.log('custom.query handler called'); return { data: 123, errors: [], timestamp: new Date() }; },
+      'custom.query': async (_ctx: any) => { console.log('custom.query handler called'); return { data: 123, errors: [], timestamp: new Date() }; },
       'custom.fail': async () => { console.log('custom.fail handler called'); throw new Error('boom'); },
       'fail': async () => { console.log('fail handler called'); throw new Error('boom'); },
       'custom.noop': async () => { console.log('custom.noop handler called'); return { emitted: true }; }
@@ -25,35 +25,35 @@ class TestMFE extends BaseMFE {
     console.log('doLoad called');
     return { status: 'loaded', timestamp: new Date(), context };
   }
-  async doRender(context: any): Promise<any> {
+  async doRender(_context: any): Promise<any> {
     console.log('doRender called');
     return { status: 'rendered', element: {}, timestamp: new Date() };
   }
-  async doRefresh(context: any): Promise<any> {
+  async doRefresh(_context: any): Promise<any> {
     console.log('doRefresh called');
     return { status: 'refreshed', timestamp: new Date() };
   }
-  async doAuthorizeAccess(context: any): Promise<any> {
+  async doAuthorizeAccess(_context: any): Promise<any> {
     console.log('doAuthorizeAccess called');
     return { status: 'authorized', timestamp: new Date() };
   }
-  async doHealth(context: any): Promise<any> {
+  async doHealth(_context: any): Promise<any> {
     console.log('doHealth called');
     return { status: 'healthy', timestamp: new Date() };
   }
-  async doDescribe(context: any): Promise<any> {
+  async doDescribe(_context: any): Promise<any> {
     console.log('doDescribe called');
     return { status: 'described', timestamp: new Date() };
   }
-  async doSchema(context: any): Promise<any> {
+  async doSchema(_context: any): Promise<any> {
     console.log('doSchema called');
     return { schema: '{}', format: 'json', timestamp: new Date() };
   }
-  async doQuery(context: any): Promise<any> {
+  async doQuery(_context: any): Promise<any> {
     console.log('doQuery called');
     return { data: 123, errors: [], timestamp: new Date() };
   }
-  async doEmit(context: any): Promise<any> {
+  async doEmit(_context: any): Promise<any> {
     console.log('doEmit called');
     return { emitted: true };
   }

--- a/packages/runtime/src/__tests__/context.test.ts
+++ b/packages/runtime/src/__tests__/context.test.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  Context,
   UserContext,
   ContextFactory,
   ContextValidator,

--- a/packages/runtime/src/__tests__/lifecycle-acceptance.coverage.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-acceptance.coverage.test.ts
@@ -3,7 +3,6 @@
  * Targets uncovered lines/branches from coverage report
  */
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { BaseMFE: ImportedBaseMFE, VALID_TRANSITIONS } = require('../base-mfe');
 
 class CoverageTestMFE extends ImportedBaseMFE {

--- a/packages/runtime/src/__tests__/lifecycle-acceptance.coverage.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-acceptance.coverage.test.ts
@@ -16,15 +16,15 @@ class CoverageTestMFE extends ImportedBaseMFE {
   public testDoSchema(): any { return this.doSchema({}); }
   public testDoQuery(): any { return this.doQuery({}); }
   public testDoEmit(): any { return this.doEmit({}); }
-  protected async doLoad(context: any): Promise<any> { return { status: 'loaded', timestamp: new Date() }; }
-  protected async doRender(context: any): Promise<any> { return { element: null, timestamp: new Date() }; }
-  protected async doRefresh(context: any): Promise<void> { return; }
-  protected async doAuthorizeAccess(context: any): Promise<boolean> { return true; }
-  protected async doHealth(context: any): Promise<any> { return { status: 'healthy', checks: [], timestamp: new Date() }; }
-  protected async doDescribe(context: any): Promise<any> { return { name: 'test', version: '1.0', type: 'tool', capabilities: [], manifest: {} }; }
-  protected async doSchema(context: any): Promise<any> { return { schema: '{}', format: 'json' }; }
-  protected async doQuery(context: any): Promise<any> { return { data: 'ok' }; }
-  protected async doEmit(context: any): Promise<any> { return { emitted: true }; }
+  protected async doLoad(_context: any): Promise<any> { return { status: 'loaded', timestamp: new Date() }; }
+  protected async doRender(_context: any): Promise<any> { return { element: null, timestamp: new Date() }; }
+  protected async doRefresh(_context: any): Promise<void> { return; }
+  protected async doAuthorizeAccess(_context: any): Promise<boolean> { return true; }
+  protected async doHealth(_context: any): Promise<any> { return { status: 'healthy', checks: [], timestamp: new Date() }; }
+  protected async doDescribe(_context: any): Promise<any> { return { name: 'test', version: '1.0', type: 'tool', capabilities: [], manifest: {} }; }
+  protected async doSchema(_context: any): Promise<any> { return { schema: '{}', format: 'json' }; }
+  protected async doQuery(_context: any): Promise<any> { return { data: 'ok' }; }
+  protected async doEmit(_context: any): Promise<any> { return { emitted: true }; }
 }
 
 describe('BaseMFE Coverage Edge Cases', () => {

--- a/packages/runtime/src/__tests__/lifecycle-acceptance.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-acceptance.test.ts
@@ -51,25 +51,25 @@ class TestMFE extends BaseMFE {
 
 
   // Capability implementations
-  protected async doLoad(context: any) { this.calls.push('doLoad'); return { status: 'loaded', timestamp: new Date() }; }
-  protected async doRender(context: any) { this.calls.push('doRender'); return { element: null }; }
-  protected async doRefresh(context: any) { this.calls.push('doRefresh'); return { success: true }; }
-  protected async doAuthorizeAccess(context: any) { this.calls.push('doAuthorizeAccess'); return { authorized: true }; }
-  protected async doHealth(context: any) { this.calls.push('doHealth'); return { status: 'ok' }; }
-  protected async doDescribe(context: any) { this.calls.push('doDescribe'); return { description: 'desc' }; }
-  protected async doSchema(context: any) { this.calls.push('doSchema'); return { schema: {} }; }
-  protected async doQuery(context: any) { this.calls.push('doQuery'); return { data: 'ok' }; }
-  protected async doEmit(context: any) { this.calls.push('doEmit'); return { ok: true }; }
+  protected async doLoad(_context: any) { this.calls.push('doLoad'); return { status: 'loaded', timestamp: new Date() }; }
+  protected async doRender(_context: any) { this.calls.push('doRender'); return { element: null }; }
+  protected async doRefresh(_context: any) { this.calls.push('doRefresh'); return { success: true }; }
+  protected async doAuthorizeAccess(_context: any) { this.calls.push('doAuthorizeAccess'); return { authorized: true }; }
+  protected async doHealth(_context: any) { this.calls.push('doHealth'); return { status: 'ok' }; }
+  protected async doDescribe(_context: any) { this.calls.push('doDescribe'); return { description: 'desc' }; }
+  protected async doSchema(_context: any) { this.calls.push('doSchema'); return { schema: {} }; }
+  protected async doQuery(_context: any) { this.calls.push('doQuery'); return { data: 'ok' }; }
+  protected async doEmit(_context: any) { this.calls.push('doEmit'); return { ok: true }; }
   protected async doUpdateControlPlaneState(context: any) { this.calls.push('doUpdateControlPlaneState'); return { acknowledged: true, correlationId: context.requestId || 'test' }; }
 
   // Custom handlers referenced in tests
-  async validateInputs(context: any) { this.calls.push('validateInputs'); }
-  async runQuery(context: any) { this.calls.push('runQuery'); }
-  async logTelemetry(context: any) { this.calls.push('logTelemetry'); }
-  async hookA(context: any) { this.calls.push('hookA'); }
-  async hookB(context: any) { this.calls.push('hookB'); }
-  async step1(context: any) { this.calls.push('step1'); }
-  async step2(context: any) { this.calls.push('step2'); }
+  async validateInputs(_context: any) { this.calls.push('validateInputs'); }
+  async runQuery(_context: any) { this.calls.push('runQuery'); }
+  async logTelemetry(_context: any) { this.calls.push('logTelemetry'); }
+  async hookA(_context: any) { this.calls.push('hookA'); }
+  async hookB(_context: any) { this.calls.push('hookB'); }
+  async step1(_context: any) { this.calls.push('step1'); }
+  async step2(_context: any) { this.calls.push('step2'); }
 }
 
 function makeContext(overrides: any = {}) {
@@ -202,31 +202,31 @@ describe('Lifecycle Acceptance (REQ-042..045, REQ-054..056)', () => {
       ];
       mfe.calls = [];
       // render
-      const r = await mfe.render(makeContext({ capability: 'render' }));
+      await mfe.render(makeContext({ capability: 'render' }));
       expect(mfe.calls).toContain('doRender');
       // refresh
       mfe.calls = [];
-      const rf = await mfe.refresh(makeContext({ capability: 'refresh' }));
+      await mfe.refresh(makeContext({ capability: 'refresh' }));
       expect(mfe.calls).toContain('doRefresh');
       // authorizeAccess
       mfe.calls = [];
-      const aa = await mfe.authorizeAccess(makeContext({ capability: 'authorizeAccess' }));
+      await mfe.authorizeAccess(makeContext({ capability: 'authorizeAccess' }));
       expect(mfe.calls).toContain('doAuthorizeAccess');
       // health
       mfe.calls = [];
-      const h = await mfe.health(makeContext({ capability: 'health' }));
+      await mfe.health(makeContext({ capability: 'health' }));
       expect(mfe.calls).toContain('doHealth');
       // describe
       mfe.calls = [];
-      const d = await mfe.describe(makeContext({ capability: 'describe' }));
+      await mfe.describe(makeContext({ capability: 'describe' }));
       expect(mfe.calls).toContain('doDescribe');
       // schema
       mfe.calls = [];
-      const s = await mfe.schema(makeContext({ capability: 'schema' }));
+      await mfe.schema(makeContext({ capability: 'schema' }));
       expect(mfe.calls).toContain('doSchema');
       // emit
       mfe.calls = [];
-      const e = await mfe.emit(makeContext({ capability: 'emit' }));
+      await mfe.emit(makeContext({ capability: 'emit' }));
       expect(mfe.calls).toContain('doEmit');
     });
     });

--- a/packages/runtime/src/__tests__/lifecycle-acceptance.test.ts
+++ b/packages/runtime/src/__tests__/lifecycle-acceptance.test.ts
@@ -38,7 +38,6 @@
 import { jest } from '@jest/globals';
 
 // Lazy import to avoid type-only coupling; adapt path if needed
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { BaseMFE } = require('../base-mfe');
 
 class TestMFE extends BaseMFE {

--- a/packages/runtime/src/__tests__/remote-mfe.integration.test.ts
+++ b/packages/runtime/src/__tests__/remote-mfe.integration.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { RemoteMFE } from '../remote-mfe';
-import type { Context, LoadResult, RenderResult, TelemetryEvent, TelemetryService } from '../base-mfe';
+import type { Context, TelemetryEvent, TelemetryService } from '../base-mfe';
 import type { DSLManifest } from '@seans-mfe/dsl';
 
 /**

--- a/packages/runtime/src/__tests__/remote-mfe.test.ts
+++ b/packages/runtime/src/__tests__/remote-mfe.test.ts
@@ -12,14 +12,13 @@
 import { RemoteMFE } from '../remote-mfe';
 import {
   createTestHarness,
-  createTestContext,
   createMockComponent,
   MFETestHarness,
   TelemetryCapture,
   ContextBuilder,
   MockDaemonWebSocketClient,
 } from './test-harness';
-import type { Context, LoadResult, RenderResult } from '../base-mfe';
+import type { Context } from '../base-mfe';
 import type { DSLManifest } from '@seans-mfe/dsl';
 
 /**
@@ -399,7 +398,7 @@ describe('RemoteMFE', () => {
     });
 
     it('should include capability in telemetry metadata', async () => {
-      const loadResult = await harness.testLoad();
+      await harness.testLoad();
       const loadTelemetry = harness.getTelemetry();
       const loadEvents = loadTelemetry.getEvents();
       

--- a/packages/runtime/src/__tests__/test-harness.test.ts
+++ b/packages/runtime/src/__tests__/test-harness.test.ts
@@ -1,7 +1,6 @@
 import {
 
 createTestHarness,
-createTestContext,
 createMockComponent,
 MFETestHarness,
 TelemetryCapture,

--- a/packages/runtime/src/__tests__/test-harness.ts
+++ b/packages/runtime/src/__tests__/test-harness.ts
@@ -54,7 +54,7 @@ export default class MockModuleFederationContainer {
     });
   }
 
-  async init(shared: any): Promise<void> {
+  async init(_shared: any): Promise<void> {
     this.initCalled = true;
     // Simulate async init with immediate resolution (no setTimeout)
     await Promise.resolve();
@@ -528,7 +528,7 @@ export function createTestHarness(config: MFETestHarnessConfig): MFETestHarness 
  * Create a context for testing
  */
 export function createTestContext(overrides?: Partial<Context>): Context {
-  return new ContextBuilder().build();
+  return overrides ? { ...new ContextBuilder().build(), ...overrides } : new ContextBuilder().build();
 }
 
 /**

--- a/packages/runtime/src/__tests__/timeout-wrapper-quick.test.ts
+++ b/packages/runtime/src/__tests__/timeout-wrapper-quick.test.ts
@@ -127,7 +127,7 @@ describe('withTimeout - quick tests', () => {
 
     try {
       await promise;
-    } catch (error) {
+    } catch {
       // Expected
     }
 

--- a/packages/runtime/src/__tests__/timeout-wrapper.test.ts
+++ b/packages/runtime/src/__tests__/timeout-wrapper.test.ts
@@ -127,7 +127,7 @@ describe('withTimeout - quick tests', () => {
 
     try {
       await promise;
-    } catch (error) {
+    } catch {
       // Expected
     }
 

--- a/packages/runtime/src/__tests__/uuid.test.ts
+++ b/packages/runtime/src/__tests__/uuid.test.ts
@@ -17,7 +17,6 @@ describe('uuidv4', () => {
       Object.defineProperty(globalThis, 'crypto', originalCrypto);
     } else {
       // Restoring an unset descriptor is best-effort.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (globalThis as any).crypto;
     }
   });
@@ -50,7 +49,6 @@ describe('uuidv4', () => {
   });
 
   it('falls back when globalThis.crypto itself is absent', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).crypto;
 
     const id = uuidv4();

--- a/packages/runtime/src/angular-remote-mfe.ts
+++ b/packages/runtime/src/angular-remote-mfe.ts
@@ -98,7 +98,6 @@ export class AngularRemoteMFE extends BaseRemoteMFE {
       throw new Error('[AngularRemoteMFE] mountComponent called outside a browser environment');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const element = (document as Document).getElementById(containerId);
     if (!element) {
       throw new Error(`[AngularRemoteMFE] DOM container #${containerId} not found`);

--- a/packages/runtime/src/base-mfe.ts
+++ b/packages/runtime/src/base-mfe.ts
@@ -496,12 +496,10 @@ export abstract class BaseMFE {
     phase: string
   ): Promise<void> {
     // Handle array of handlers (REQ-045)
-    const handlers = Array.isArray(hookConfig.handler) 
-      ? hookConfig.handler 
+    const handlers = Array.isArray(hookConfig.handler)
+      ? hookConfig.handler
       : [hookConfig.handler];
-    
-    let lastError: Error | null = null;
-    
+
     for (const handlerName of handlers) {
       try {
         // Contained flag: wrap in try-catch (REQ-042)
@@ -518,7 +516,6 @@ export abstract class BaseMFE {
         }
       } catch (error) {
         // Handler failed
-        lastError = error as Error;
         await this.emitHookFailure(hookName, handlerName, error as Error, context, phase === 'main' ? 'error' : 'warn');
         
         // REQ-042: Main phase failures propagate immediately

--- a/packages/runtime/src/handlers/auth.ts
+++ b/packages/runtime/src/handlers/auth.ts
@@ -54,7 +54,6 @@ export async function validateJWT(context: Context): Promise<void> {
     // string defeats rspack/webpack static analysis, so the bundler never
     // walks the jsonwebtoken module graph (which would pull in stream/util/
     // buffer/crypto and require browser stubs to compile).
-    // eslint-disable-next-line no-eval
     const jwt = eval('require')('jsonwebtoken');
     const decoded = jwt.verify(token, secret, { algorithms: ['HS256'] });
     context.user = decoded;

--- a/packages/runtime/src/remote-mfe.ts
+++ b/packages/runtime/src/remote-mfe.ts
@@ -61,7 +61,6 @@ export class RemoteMFE extends BaseRemoteMFE {
       throw new Error('[RemoteMFE] mountComponent called outside a browser environment');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const element = (document as Document).getElementById(containerId);
     if (!element) {
       throw new Error(`[RemoteMFE] DOM container #${containerId} not found`);

--- a/src/codegen/APIGenerator/DatabaseGenerator/DatabaseGenerator.js
+++ b/src/codegen/APIGenerator/DatabaseGenerator/DatabaseGenerator.js
@@ -1,5 +1,3 @@
-const fs = require('fs-extra');
-const path = require('path');
 const chalk = require('chalk');
 const { MongoDBGenerator } = require('./generators/MongoDBGenerator');
 const { SQLiteGenerator } = require('./generators/SQLiteGenerator');

--- a/src/codegen/APIGenerator/DatabaseGenerator/__tests__/MigrationGenerator.test.js
+++ b/src/codegen/APIGenerator/DatabaseGenerator/__tests__/MigrationGenerator.test.js
@@ -1,8 +1,7 @@
 const { MigrationGenerator } = require('../generators/MigrationGenerator');
-const { 
-  simpleSchema, 
+const {
+  simpleSchema,
   relationshipSchema,
-  validationSchema,
   multiSchemaSpec
 } = require('./fixtures/openapi-schemas');
 const fs = require('fs-extra');

--- a/src/codegen/APIGenerator/DatabaseGenerator/__tests__/MongoDBGenerator.test.js
+++ b/src/codegen/APIGenerator/DatabaseGenerator/__tests__/MongoDBGenerator.test.js
@@ -1,10 +1,9 @@
 const { MongoDBGenerator } = require('../generators/MongoDBGenerator');
-const { 
-  simpleSchema, 
-  complexSchema, 
+const {
+  simpleSchema,
+  complexSchema,
   relationshipSchema,
   validationSchema,
-  mongoSpecificSchema,
   multiSchemaSpec
 } = require('./fixtures/openapi-schemas');
 const fs = require('fs-extra');

--- a/src/codegen/APIGenerator/DatabaseGenerator/__tests__/SQLiteGenerator.test.js
+++ b/src/codegen/APIGenerator/DatabaseGenerator/__tests__/SQLiteGenerator.test.js
@@ -1,10 +1,9 @@
 const { SQLiteGenerator } = require('../generators/SQLiteGenerator');
-const { 
-  simpleSchema, 
-  complexSchema, 
+const {
+  simpleSchema,
+  complexSchema,
   relationshipSchema,
   validationSchema,
-  sqliteSpecificSchema,
   multiSchemaSpec
 } = require('./fixtures/openapi-schemas');
 const fs = require('fs-extra');

--- a/src/codegen/APIGenerator/DatabaseGenerator/generators/BaseGenerator.js
+++ b/src/codegen/APIGenerator/DatabaseGenerator/generators/BaseGenerator.js
@@ -28,11 +28,11 @@ class BaseGenerator {
     await this.generateModelIndex(modelsDir, spec.components.schemas);
   }
 
-  generateModelFile(schemaName, schema) {
+  generateModelFile(_schemaName, _schema) {
     throw new Error('generateModelFile must be implemented by subclass');
   }
 
-  async generateModelIndex(modelsDir, schemas) {
+  async generateModelIndex(_modelsDir, _schemas) {
     throw new Error('generateModelIndex must be implemented by subclass');
   }
 

--- a/src/codegen/APIGenerator/RouteGenerator/RouteGenerator.js
+++ b/src/codegen/APIGenerator/RouteGenerator/RouteGenerator.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 const chalk = require('chalk');
-const { SchemaGenerator } = require('../utils/SchemaGenerator');
 const { PathGenerator } = require('../utils/PathGenerator');
 const { NameGenerator } = require('../utils/NameGenerator');
 

--- a/src/codegen/APIGenerator/RouteGenerator/__tests__/PathGenerator.test.js
+++ b/src/codegen/APIGenerator/RouteGenerator/__tests__/PathGenerator.test.js
@@ -1,7 +1,6 @@
 const { PathGenerator } = require('../../utils/PathGenerator');
 const { SchemaGenerator } = require('../../utils/SchemaGenerator');
-const { NameGenerator } = require('../../utils/NameGenerator');
-const { simpleSpec, petStoreSpec, operationExamples } = require('./fixtures/openapi-specs');
+const { simpleSpec } = require('./fixtures/openapi-specs');
 
 // Mock SchemaGenerator since we're testing PathGenerator in isolation
 jest.mock('../../utils/SchemaGenerator');

--- a/src/codegen/APIGenerator/RouteGenerator/__tests__/RouteGenerator.test.js
+++ b/src/codegen/APIGenerator/RouteGenerator/__tests__/RouteGenerator.test.js
@@ -1,11 +1,8 @@
 const fs = require('fs-extra');
 const path = require('path');
-const chalk = require('chalk');
 const { RouteGenerator } = require('../RouteGenerator');
 const { PathGenerator } = require('../../utils/PathGenerator');
-const { SchemaGenerator } = require('../../utils/SchemaGenerator');
-const { NameGenerator } = require('../../utils/NameGenerator');
-const { simpleSpec, petStoreSpec } = require('./fixtures/openapi-specs');
+const { simpleSpec } = require('./fixtures/openapi-specs');
 
 // Mock all dependencies
 jest.mock('fs-extra');

--- a/src/codegen/APIGenerator/__tests__/generated-api-regressions.test.js
+++ b/src/codegen/APIGenerator/__tests__/generated-api-regressions.test.js
@@ -11,7 +11,6 @@ const os = require('os');
 const path = require('path');
 
 const { NameGenerator } = require('../utils/NameGenerator');
-const { PathGenerator } = require('../utils/PathGenerator');
 const { RouteGenerator } = require('../RouteGenerator/RouteGenerator');
 const { ControllerGenerator } = require('../ControllerGenerator/ControllerGenerator');
 const { DatabaseAdapter } = require('../ControllerGenerator/adapters/DatabaseAdapter');

--- a/src/codegen/APIGenerator/utils/PathGenerator.js
+++ b/src/codegen/APIGenerator/utils/PathGenerator.js
@@ -10,7 +10,7 @@ class PathGenerator {
     const routes = [];
 
     paths.forEach(([path, operations]) => {
-      const { parameters: pathParams, ...pathOperations } = operations;
+      const { parameters: _pathParams, ...pathOperations } = operations;
       
       Object.entries(pathOperations).forEach(([method, operation]) => {
         const functionName = this.generateMethodName(method, resourceName, path, operation);
@@ -21,7 +21,7 @@ class PathGenerator {
           validationSchemas.push(validationSchema);
         }
 
-        const route = this.generateRoute(method, path, functionName, operation, resourceName);
+        const route = this.generateRoute(method, path, functionName, operation);
         routes.push(route);
         console.log("is it the path", path)
       });
@@ -40,8 +40,8 @@ class PathGenerator {
     return NameGenerator.generateControllerMethodName(method, resourceName, path, operation);
   }
 
-  static generateRoute(method, path, functionName, operation, resourceName) {
-    const routePath = this.normalizeRoutePath(path, resourceName);
+  static generateRoute(method, path, functionName, operation) {
+    const routePath = this.normalizeRoutePath(path);
     const middlewares = this.generateMiddleware(operation);
     
     let routeStr = `router.${method.toLowerCase()}('${routePath}'`;
@@ -55,7 +55,7 @@ class PathGenerator {
     return `${routeStr});`;
   }
 
-  static normalizeRoutePath(path, resourceName) {
+  static normalizeRoutePath(path) {
     // The router is mounted at the resource's URL segment, so strip the
     // path's own first segment. resourceName may be camelCased while the
     // URL segment is snake_case/kebab-case, so cutting by the derived name

--- a/src/codegen/APIGenerator/utils/SchemaGenerator.js
+++ b/src/codegen/APIGenerator/utils/SchemaGenerator.js
@@ -1,5 +1,5 @@
 class SchemaGenerator {
-  static generateValidationSchema(operation, components) {
+  static generateValidationSchema(operation) {
     const schemas = {
       body: this.generateRequestBodySchema(operation),
       params: this.generateParametersSchema(operation),

--- a/src/commands/__tests__/create-api.test.js
+++ b/src/commands/__tests__/create-api.test.js
@@ -1,12 +1,10 @@
 // src/commands/__tests__/create-api.test.js
 // Import test utils first to activate module mocks
-const { 
-  mockProcessExit, 
-  mockConsole, 
+const {
+  mockProcessExit,
+  mockConsole,
   setupCommonMocks,
   mockFs,
-  mockExec,
-  expectProcessExit,
   createTestData
 } = require('./test-utils');
 

--- a/src/commands/__tests__/remote-generate-capability.test.ts
+++ b/src/commands/__tests__/remote-generate-capability.test.ts
@@ -3,8 +3,6 @@
  * Following TDD principles - testing REQ-REMOTE-003 (single-capability generation)
  */
 
-import * as fs from 'fs-extra';
-
 jest.mock('fs-extra');
 
 jest.mock('chalk', () => ({

--- a/src/commands/__tests__/remote-generate.test.ts
+++ b/src/commands/__tests__/remote-generate.test.ts
@@ -4,7 +4,6 @@
  */
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
 
 // Mock dependencies before importing command
 jest.mock('fs-extra');
@@ -50,7 +49,7 @@ let mockConsole: { log: jest.SpyInstance; error: jest.SpyInstance };
 
 // Import after mocks
 import { remoteGenerateCommand } from '../remote-generate';
-import { parseAndValidateDirectory, formatErrorsForCLI } from '@seans-mfe/dsl';
+import { parseAndValidateDirectory } from '@seans-mfe/dsl';
 
 import { generateAllFiles, writeGeneratedFiles } from '@seans-mfe/codegen';
 
@@ -138,7 +137,7 @@ describe('remote:generate Command', () => {
 
       try {
         await remoteGenerateCommand();
-      } catch (e) {
+      } catch {
         // Expected
       }
 

--- a/src/commands/__tests__/remote-init-angular.test.ts
+++ b/src/commands/__tests__/remote-init-angular.test.ts
@@ -6,7 +6,6 @@
  */
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
 import { execSync } from 'child_process';
 
 jest.mock('fs-extra');

--- a/src/commands/__tests__/remote-init.test.ts
+++ b/src/commands/__tests__/remote-init.test.ts
@@ -4,7 +4,6 @@
  */
 
 import * as fs from 'fs-extra';
-import * as path from 'path';
 import { execSync } from 'child_process';
 
 // Mock dependencies before importing command

--- a/src/commands/build/__tests__/docker.test.ts
+++ b/src/commands/build/__tests__/docker.test.ts
@@ -168,7 +168,6 @@ describe('buildDockerCommand', () => {
     await buildDockerCommand({ framework: 'react', output: '/custom/Dockerfile' });
 
     expect(fsExtra.outputFile).toHaveBeenCalledWith('/custom/Dockerfile', expect.any(String));
-    const [, result] = (await buildDockerCommand({ framework: 'react', output: '/custom/Dockerfile' }), []);
     expect(fsExtra.outputFile.mock.calls[0][0]).toBe('/custom/Dockerfile');
   });
 });

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -53,12 +53,15 @@ async function cleanupTempDirs(): Promise<void> {
 process.on('SIGINT', async () => {
   console.log(chalk.yellow('\nReceived SIGINT. Cleaning up...'));
   await cleanupTempDirs();
+  // A signal handler has no caller to throw to; this is the process exit.
+  // eslint-disable-next-line no-process-exit
   process.exit(1);
 });
 
 process.on('SIGTERM', async () => {
   console.log(chalk.yellow('\nReceived SIGTERM. Cleaning up...'));
   await cleanupTempDirs();
+  // eslint-disable-next-line no-process-exit -- same as the SIGINT handler above
   process.exit(1);
 });
 
@@ -184,7 +187,7 @@ async function developmentDeploy(options: DeployOptions): Promise<void> {
       execSync(`docker stop ${containerName}`, { stdio: 'ignore' });
       execSync(`docker rm ${containerName}`, { stdio: 'ignore' });
       console.log(chalk.blue(`Removed existing container: ${containerName}`));
-    } catch (e) {
+    } catch {
       // Container doesn't exist, continue
     }
 
@@ -239,7 +242,7 @@ async function waitForContainer(containerName: string, timeout: number = 30000):
       if (status === 'running') {
         return true;
       }
-    } catch (e) {
+    } catch {
       // Container not ready yet
     }
     await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/framework/loader.ts
+++ b/src/framework/loader.ts
@@ -61,7 +61,6 @@ export function loadFrameworkPlugin(framework: string): BaseFrameworkPlugin {
       // In ts source:      __dirname is <root>/src/framework/
       // Either way, ../../packages/<dir> reaches the package.
       const builtinPath = path.resolve(__dirname, '..', '..', 'packages', builtinDir);
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const mod = require(builtinPath);
       const plugin: unknown = mod.frameworkPlugin ?? mod.default;
       if (isFrameworkPlugin(plugin)) {
@@ -74,7 +73,6 @@ export function loadFrameworkPlugin(framework: string): BaseFrameworkPlugin {
 
   // 2. Try npm package resolution (third-party plugins)
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const mod = require(packageName);
     const plugin: unknown = mod.frameworkPlugin ?? mod.default;
 

--- a/src/hooks/__tests__/postrun.test.ts
+++ b/src/hooks/__tests__/postrun.test.ts
@@ -124,7 +124,6 @@ afterEach(() => {
 
 describe('postrun hook', () => {
   test('no-ops when SEANS_MFE_DAEMON_URL is not set', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hook = require('../postrun').default;
     await hook.call(buildHookContext(), {});
     expect(lastMockWs).toBeNull();
@@ -139,7 +138,6 @@ describe('postrun hook', () => {
     // Patch globalThis.WebSocket with our mock
     (globalThis as any).WebSocket = createMockWsClass();
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hook = require('../postrun').default;
     const ctx = buildHookContext();
 
@@ -176,7 +174,6 @@ describe('postrun hook', () => {
     process.env.SEANS_MFE_DAEMON_URL = 'ws://localhost:9999/graphql';
     (globalThis as any).WebSocket = createMockWsClass();
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hook = require('../postrun').default;
 
     const hookPromise = hook.call(buildHookContext(), {});
@@ -199,7 +196,6 @@ describe('postrun hook', () => {
   });
 
   test('no latency added when SEANS_MFE_DAEMON_URL is unset (<10ms)', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const hook = require('../postrun').default;
     const start = Date.now();
     await hook.call(buildHookContext(), {});

--- a/src/hooks/__tests__/postrun.test.ts
+++ b/src/hooks/__tests__/postrun.test.ts
@@ -18,8 +18,6 @@ import * as path from 'path';
 // Mock WebSocket
 // ---------------------------------------------------------------------------
 
-type WsListener = (event: { data: string }) => void;
-
 interface MockWsInstance {
   url: string;
   sentFrames: string[];
@@ -82,19 +80,12 @@ function createMockWsClass() {
 
 const OFFLINE_CACHE = path.join(os.homedir(), '.cache', 'seans-mfe', 'daemon-offline');
 
-const OFFLINE_TTL_MS = 60_000;
-
 function clearOfflineCache() {
   try {
     fs.unlinkSync(OFFLINE_CACHE);
   } catch {
     /* ignore */
   }
-}
-
-function writeOfflineCache(offsetMs = OFFLINE_TTL_MS + 1_000) {
-  fs.mkdirSync(path.dirname(OFFLINE_CACHE), { recursive: true });
-  fs.writeFileSync(OFFLINE_CACHE, String(Date.now() + offsetMs));
 }
 
 function buildHookContext(overrides: Record<string, unknown> = {}) {
@@ -186,7 +177,6 @@ describe('postrun hook', () => {
     expect(fs.existsSync(OFFLINE_CACHE)).toBe(true);
 
     // Second call — should skip without creating a new socket
-    const prevWs = lastMockWs;
     lastMockWs = null;
     await hook.call(buildHookContext(), {});
     expect(lastMockWs).toBeNull(); // no new socket created

--- a/src/hooks/command-not-found.ts
+++ b/src/hooks/command-not-found.ts
@@ -22,6 +22,8 @@ const hook: Hook<'command_not_found'> = async function(opts) {
       },
     };
     process.stdout.write(JSON.stringify(envelope) + '\n');
+    // Same envelope exit-code contract as BaseCommand.run() (ADR-018).
+    // eslint-disable-next-line no-process-exit
     process.exit(2);
   }
   // No --json: oclif renders its default error and suggestion text

--- a/src/hooks/postrun.ts
+++ b/src/hooks/postrun.ts
@@ -169,7 +169,6 @@ function getWebSocketClass(): WebSocketCtor | null {
   }
   // 'ws' npm package
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const ws = require('ws') as { default?: unknown };
     return (ws.default ?? ws) as WebSocketCtor;
   } catch {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -14,7 +14,6 @@
  */
 
 import { spawn } from 'child_process';
-import * as path from 'path';
 import * as fs from 'fs-extra';
 import { loadToolRegistry, buildArgv, McpToolDefinition } from './tool-registry';
 import type { CommandResult } from '@seans-mfe/contracts';
@@ -90,7 +89,7 @@ export async function executeToolCall(
     child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
     child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
 
-    child.on('close', (code) => {
+    child.on('close', () => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -157,7 +156,7 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
         if (response !== null) {
           process.stdout.write(JSON.stringify(response) + '\n');
         }
-      } catch (err) {
+      } catch {
         const errResponse = {
           jsonrpc: '2.0',
           id: null,
@@ -168,6 +167,9 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
     }
   });
 
+  // This is the process's own stdio loop ending (parent disconnected) —
+  // there is no caller above it to throw to.
+  // eslint-disable-next-line no-process-exit
   process.stdin.on('end', () => { process.exit(0); });
 }
 

--- a/src/utils/__tests__/manifestValidator.test.js
+++ b/src/utils/__tests__/manifestValidator.test.js
@@ -10,7 +10,6 @@ const {
   KNOWN_PLUGINS,
   KNOWN_TRANSFORMS,
 } = require('../manifestValidator');
-const chalk = require('chalk');
 
 // Mock console methods
 const mockConsole = () => {


### PR DESCRIPTION
## Summary

Closes out #208 (`npm run lint` currently reports 276 warnings, 0 errors) exactly per its own suggested plan: a mechanical `eslint --fix` commit first, then a manual judgement-call pass file by file.

Starting point on this branch was actually 157, not 276 — #321/#323 (typed-`any` cleanup, merged earlier) already took a large bite out of it as a side effect. This PR finishes the rest.

**Commit 1** (`eslint --fix`): drops 29 now-unnecessary `eslint-disable-next-line` comments (`no-console`, `no-eval`, `@typescript-eslint/no-var-requires`) — none of those rules are configured as errors/warnings in `eslint.config.js` anymore. Also removes one dead `eslint-disable-next-line import/first` that was an outright **error** (`eslint-plugin-import` was never wired into this flat config, so the directive itself was invalid).

**Commit 2** (manual pass): works through the remaining 128 warnings — `@typescript-eslint/no-unused-vars` and `no-process-exit` — with per-case judgement, not blanket suppression:
- **`no-process-exit` (6 sites, all justified with inline comments):** BaseCommand's `--json` envelope exit-code contract (ADR-018), `deploy.ts`'s SIGINT/SIGTERM handlers, the `command_not_found` hook's JSON envelope path, and the MCP server's stdio-closed shutdown. All are genuine process boundaries — throwing there would either lose the required exit code or have no catcher.
- **Dead code removed**, not just silenced: unused imports/consts across ~25 files, a stray comma-operator expression in `docker.test.ts` that redundantly re-invoked the command under test, and a dead `lastError` variable in `base-mfe.ts`'s `executeHook`.
- **Two real (if currently dormant) bugs fixed**, found by asking *why* a parameter went unused instead of reflexively `_`-prefixing it:
  - `test-harness.ts`'s `createTestContext(overrides)` silently discarded `overrides` and always returned a bare default context — now merges them, matching the pattern already used elsewhere in the same file.
  - `PathGenerator.js`'s `normalizeRoutePath(path, resourceName)` never used `resourceName` — its own comment already explains why (camelCase vs. kebab-case URL segments make a resourceName-based strip wrong) — so the parameter was removed rather than kept as a footgun, threaded through `generateRoute`'s call site too.
- **The bulk (61 of 128)** was one repeated pattern across 4 runtime test files: `TestMFE` stub methods implementing `BaseMFE`'s abstract capability methods where the trivial test body doesn't need `context` — `_`-prefixed, since the parameter is part of the interface being implemented, not dead.

## Acceptance criteria (from #208)

- [x] `npm run lint` exits clean — 0 warnings, 0 errors (not "every warning individually justified"; got it to actually zero)
- [x] No `any` reintroduced — N/A here, #321 already made that an `error`-level gate
- [x] `npm run typecheck` and `npm test` stay green
- [x] Done as a standalone PR off `main`, staged exactly as suggested (auto-fix commit, then manual commits)

## Local test runbook

```bash
npm run build:packages
npm run lint          # 0 warnings, 0 errors
npm run typecheck
npm run build
git diff --exit-code schemas/   # no drift
npm test -- --ci --coverage \
  --testPathIgnorePatterns="/examples/" \
  --testPathIgnorePatterns="NodemonServer.test.js" \
  --testPathIgnorePatterns="create-shell.test.js" \
  --testPathIgnorePatterns="json-contract.test.ts" \
  --testPathIgnorePatterns="remote-mfe.integration.test.ts"   # exact CI command
```

Correct result: `npm run lint` prints nothing but the command line itself (no warnings block at all). Full run: `117 passed, 117 total` suites / `2160 passed, 2160 total` tests, exit 0, coverage thresholds unchanged from before this PR.

If anything regresses, `git blame` the specific warning category — the two commits are deliberately separated (mechanical vs. judgement) so a bad call is easy to isolate.

Closes #208


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzqLdzdZ3NhXsJym184suj)_