### PR TITLE
fix: forward JWT to upstream BFF sources in meridian-station MFEs

### DIFF
--- a/examples/meridian-station/meridian-cargo-ops/.meshrc.yaml
+++ b/examples/meridian-station/meridian-cargo-ops/.meshrc.yaml
@@ -9,10 +9,16 @@ sources:
     handler:
       openapi:
         source: ./specs/harbormaster.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
   - name: StellarLedger
     handler:
       openapi:
         source: ./specs/stellar-ledger.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query

--- a/examples/meridian-station/meridian-cargo-ops/mfe-manifest.yaml
+++ b/examples/meridian-station/meridian-cargo-ops/mfe-manifest.yaml
@@ -67,10 +67,16 @@ data:
       handler:
         openapi:
           source: ./specs/harbormaster.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
     - name: StellarLedger
       handler:
         openapi:
           source: ./specs/stellar-ledger.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query

--- a/examples/meridian-station/meridian-cargo-ops/src/platform/base-mfe/bootstrap.ts
+++ b/examples/meridian-station/meridian-cargo-ops/src/platform/base-mfe/bootstrap.ts
@@ -125,7 +125,11 @@ const manifest = {
         "name": "Harbormaster",
         "handler": {
           "openapi": {
-            "source": "./specs/harbormaster.yaml"
+            "source": "./specs/harbormaster.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         }
       },
@@ -133,7 +137,11 @@ const manifest = {
         "name": "StellarLedger",
         "handler": {
           "openapi": {
-            "source": "./specs/stellar-ledger.yaml"
+            "source": "./specs/stellar-ledger.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [

--- a/examples/meridian-station/meridian-concourse/.meshrc.yaml
+++ b/examples/meridian-station/meridian-concourse/.meshrc.yaml
@@ -9,6 +9,9 @@ sources:
     handler:
       openapi:
         source: ./specs/station-os.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query
@@ -25,6 +28,9 @@ sources:
     handler:
       openapi:
         source: ./specs/stellar-ledger.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query
@@ -36,6 +42,9 @@ sources:
     handler:
       openapi:
         source: ./specs/harbormaster.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
 serve:
   endpoint: /graphql
   playground: true

--- a/examples/meridian-station/meridian-concourse/mfe-manifest.yaml
+++ b/examples/meridian-station/meridian-concourse/mfe-manifest.yaml
@@ -62,6 +62,9 @@ data:
       handler:
         openapi:
           source: ./specs/station-os.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query
@@ -74,6 +77,9 @@ data:
       handler:
         openapi:
           source: ./specs/stellar-ledger.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query
@@ -83,6 +89,9 @@ data:
       handler:
         openapi:
           source: ./specs/harbormaster.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
   mockSwitch:
     enabled: true
   serve:

--- a/examples/meridian-station/meridian-concourse/src/platform/base-mfe/bootstrap.ts
+++ b/examples/meridian-station/meridian-concourse/src/platform/base-mfe/bootstrap.ts
@@ -119,7 +119,11 @@ const manifest = {
         "name": "StationOS",
         "handler": {
           "openapi": {
-            "source": "./specs/station-os.yaml"
+            "source": "./specs/station-os.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [
@@ -149,7 +153,11 @@ const manifest = {
         "name": "StellarLedger",
         "handler": {
           "openapi": {
-            "source": "./specs/stellar-ledger.yaml"
+            "source": "./specs/stellar-ledger.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [
@@ -171,7 +179,11 @@ const manifest = {
         "name": "Harbormaster",
         "handler": {
           "openapi": {
-            "source": "./specs/harbormaster.yaml"
+            "source": "./specs/harbormaster.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         }
       }

--- a/examples/meridian-station/meridian-crew-services/.meshrc.yaml
+++ b/examples/meridian-station/meridian-crew-services/.meshrc.yaml
@@ -9,6 +9,9 @@ sources:
     handler:
       openapi:
         source: ./specs/station-os.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query
@@ -25,6 +28,9 @@ sources:
     handler:
       openapi:
         source: ./specs/stellar-ledger.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query

--- a/examples/meridian-station/meridian-crew-services/mfe-manifest.yaml
+++ b/examples/meridian-station/meridian-crew-services/mfe-manifest.yaml
@@ -65,6 +65,9 @@ data:
       handler:
         openapi:
           source: ./specs/station-os.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query
@@ -77,6 +80,9 @@ data:
       handler:
         openapi:
           source: ./specs/stellar-ledger.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query

--- a/examples/meridian-station/meridian-crew-services/src/platform/base-mfe/bootstrap.ts
+++ b/examples/meridian-station/meridian-crew-services/src/platform/base-mfe/bootstrap.ts
@@ -125,7 +125,11 @@ const manifest = {
         "name": "StationOS",
         "handler": {
           "openapi": {
-            "source": "./specs/station-os.yaml"
+            "source": "./specs/station-os.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [
@@ -155,7 +159,11 @@ const manifest = {
         "name": "StellarLedger",
         "handler": {
           "openapi": {
-            "source": "./specs/stellar-ledger.yaml"
+            "source": "./specs/stellar-ledger.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [

--- a/examples/meridian-station/meridian-docking-control/.meshrc.yaml
+++ b/examples/meridian-station/meridian-docking-control/.meshrc.yaml
@@ -9,10 +9,16 @@ sources:
     handler:
       openapi:
         source: ./specs/harbormaster.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
   - name: StellarLedger
     handler:
       openapi:
         source: ./specs/stellar-ledger.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query

--- a/examples/meridian-station/meridian-docking-control/mfe-manifest.yaml
+++ b/examples/meridian-station/meridian-docking-control/mfe-manifest.yaml
@@ -70,10 +70,16 @@ data:
       handler:
         openapi:
           source: ./specs/harbormaster.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
     - name: StellarLedger
       handler:
         openapi:
           source: ./specs/stellar-ledger.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query

--- a/examples/meridian-station/meridian-docking-control/src/platform/base-mfe/bootstrap.ts
+++ b/examples/meridian-station/meridian-docking-control/src/platform/base-mfe/bootstrap.ts
@@ -131,7 +131,11 @@ const manifest = {
         "name": "Harbormaster",
         "handler": {
           "openapi": {
-            "source": "./specs/harbormaster.yaml"
+            "source": "./specs/harbormaster.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         }
       },
@@ -139,7 +143,11 @@ const manifest = {
         "name": "StellarLedger",
         "handler": {
           "openapi": {
-            "source": "./specs/stellar-ledger.yaml"
+            "source": "./specs/stellar-ledger.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [

--- a/examples/meridian-station/meridian-docking-simulation/.meshrc.yaml
+++ b/examples/meridian-station/meridian-docking-simulation/.meshrc.yaml
@@ -9,10 +9,16 @@ sources:
     handler:
       openapi:
         source: ./specs/harbormaster.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
   - name: StationOS
     handler:
       openapi:
         source: ./specs/station-os.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
 serve:
   endpoint: /graphql
   playground: true

--- a/examples/meridian-station/meridian-docking-simulation/mfe-manifest.yaml
+++ b/examples/meridian-station/meridian-docking-simulation/mfe-manifest.yaml
@@ -60,10 +60,16 @@ data:
       handler:
         openapi:
           source: ./specs/harbormaster.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
     - name: StationOS
       handler:
         openapi:
           source: ./specs/station-os.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
   mockSwitch:
     enabled: true
   serve:

--- a/examples/meridian-station/meridian-docking-simulation/src/platform/base-mfe/bootstrap.ts
+++ b/examples/meridian-station/meridian-docking-simulation/src/platform/base-mfe/bootstrap.ts
@@ -131,7 +131,11 @@ const manifest = {
         "name": "Harbormaster",
         "handler": {
           "openapi": {
-            "source": "./specs/harbormaster.yaml"
+            "source": "./specs/harbormaster.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         }
       },
@@ -139,7 +143,11 @@ const manifest = {
         "name": "StationOS",
         "handler": {
           "openapi": {
-            "source": "./specs/station-os.yaml"
+            "source": "./specs/station-os.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         }
       }

--- a/examples/meridian-station/meridian-life-support/.meshrc.yaml
+++ b/examples/meridian-station/meridian-life-support/.meshrc.yaml
@@ -9,6 +9,9 @@ sources:
     handler:
       openapi:
         source: ./specs/station-os.yaml
+        operationHeaders:
+          Authorization: Bearer {context.jwt}
+          X-Request-ID: '{context.requestId}'
     transforms:
       - hoistField:
           - typeName: Query

--- a/examples/meridian-station/meridian-life-support/mfe-manifest.yaml
+++ b/examples/meridian-station/meridian-life-support/mfe-manifest.yaml
@@ -69,6 +69,9 @@ data:
       handler:
         openapi:
           source: ./specs/station-os.yaml
+          operationHeaders:
+            Authorization: 'Bearer {context.jwt}'
+            X-Request-ID: '{context.requestId}'
       transforms:
         - hoistField:
             - typeName: Query

--- a/examples/meridian-station/meridian-life-support/src/platform/base-mfe/bootstrap.ts
+++ b/examples/meridian-station/meridian-life-support/src/platform/base-mfe/bootstrap.ts
@@ -131,7 +131,11 @@ const manifest = {
         "name": "StationOS",
         "handler": {
           "openapi": {
-            "source": "./specs/station-os.yaml"
+            "source": "./specs/station-os.yaml",
+            "operationHeaders": {
+              "Authorization": "Bearer {context.jwt}",
+              "X-Request-ID": "{context.requestId}"
+            }
           }
         },
         "transforms": [


### PR DESCRIPTION
## Summary

Closes #21.

Issue #21 originally asked for an automated live-server smoke test proving JWT forwarding through the BFF layer. Investigation found no such automated coverage exists anywhere (`bff.test.js` mocks `execSync`/`spawn`; the Playwright suite targets a static DOM fixture, not a live BFF). Per user direction, the more concrete and actionable problem is the one this PR fixes: **meridian-station's 6 BFF-bearing MFEs never forward the caller's JWT to upstream REST APIs, while abc-kids does.**

- All BFF MFEs extract the incoming `Authorization` header into `context.jwt` via the generated `mesh-context.js` Envelop plugin — that part is identical everywhere.
- `examples/abc-kids/flappy` and `multiplication-quiz` declare `operationHeaders: { Authorization: 'Bearer {context.jwt}', X-Request-ID: '{context.requestId}' }` on their OpenAPI sources, so the extracted JWT actually reaches upstream. This also matches the current `bff:init` scaffold default (`packages/bff-plugin/templates/mfe-manifest.yaml.ejs`).
- None of meridian-station's 6 BFF manifests (`meridian-cargo-ops`, `meridian-concourse`, `meridian-crew-services`, `meridian-docking-control`, `meridian-docking-simulation`, `meridian-life-support`) declared `operationHeaders` — 0 occurrences across all 7 manifests. The JWT was extracted into context and then silently dropped.
- Ruled out "intentional" explanations: neither upstream OpenAPI spec (`harbormaster.yaml`, `stellar-ledger.yaml`, `station-os.yaml`) declares a security scheme, and PDR-007 ("reference apps model messy reality") is about API *shape* inconsistency, not auth-forwarding — no rationale found for omitting it here. This was drift, not design.

## Changes

- Added the standard `operationHeaders` stanza to every source (`handler.openapi`) across the 6 affected `mfe-manifest.yaml` files — 12 sources total.
- Regenerated all derived files (`.meshrc.yaml`, `bootstrap.ts`) via the real CLI (`node examples/meridian-station/scripts/generate.mjs`, plus a direct `remote:generate` for `meridian-docking-simulation`, which isn't yet in that script's fleet roster) — no generated file was hand-edited, per the project's regen-invariant discipline.
- Verified the diff is limited to exactly the expected additions: `mfe-manifest.yaml`, `.meshrc.yaml`, and `bootstrap.ts` (which embeds the manifest JSON) for each of the 6 MFEs — no unrelated drift.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run check:mfe-consistency` — all 21 MFEs internally consistent
- [x] `node examples/meridian-station/scripts/generate.mjs --check` — confirmed clean baseline *before* edits (no pre-existing drift), and confirmed a second regen after committing produces zero further diff (fixed point reached)
- [x] Manually reviewed `git diff --stat` for the full change — exactly 18 files (`mfe-manifest.yaml` + `.meshrc.yaml` + `bootstrap.ts` × 6 MFEs), no incidental changes

## Local-test runbook

```bash
git checkout claude/issue-21-bff-jwt-forwarding-consistency
npm run build:packages   # rebuild CLI packages remote:generate depends on

# Confirm every source in every affected manifest now has operationHeaders:
grep -c operationHeaders examples/meridian-station/*/mfe-manifest.yaml
# meridian-cargo-ops: 2, meridian-concourse: 3, meridian-crew-services: 2,
# meridian-docking-control: 2, meridian-docking-simulation: 2, meridian-life-support: 1

# Confirm regen produces zero drift against the committed generated files:
node examples/meridian-station/scripts/generate.mjs --check
# → "Regen invariant holds: no drift."

# End-to-end: start any affected MFE's BFF and confirm the Authorization
# header reaches the upstream mock API, e.g.:
cd examples/meridian-station/meridian-cargo-ops
npm run dev
# then call the GraphQL endpoint with an Authorization header and check the
# harbormaster-api / stellar-ledger-api mock server logs show the same
# Authorization header on the proxied request.
```

If the grep counts don't match, or `generate.mjs --check` reports a diff, that's the first place to look — it means a manifest edit and its generated output have drifted apart again.

**Not fixed by this PR** (separate, follow-up scope if wanted): there is still no automated test asserting this behavior end-to-end against a live server — the original literal ask in #21. Given the user's explicit redirect toward the JWT-forwarding inconsistency as the real concern, and that this fix makes meridian-station consistent with the abc-kids reference apps and the current scaffold default, this PR treats that as sufficient to close #21. Happy to open a new issue for the automated smoke test if desired.

Refs #21


---
_Generated by [Claude Code](https://claude.ai/code/session_01WzqLdzdZ3NhXsJym184suj)_