### PR TITLE
feat: fresh-scaffold typecheck CI gate for base-mfe template drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -351,3 +351,13 @@ jobs:
         # Re-runs remote:generate across the reference fleet + derives seeds,
         # then fails on any drift (#274 discipline, #276 reference app).
         run: node examples/meridian-station/scripts/generate.mjs --check
+
+      - name: Template typecheck gate — fresh scaffold, real install, real tsc (#281)
+        # The other checks above regenerate against committed examples or
+        # assert in-memory string content; neither runs a real `npm install`
+        # against a freshly generated project. Both regressions that motivated
+        # this gate (Angular's tsconfig.app.json.ejs shipping a broken "//"
+        # comment key, and React's bootstrap.ts.ejs passing a partial Context)
+        # were masked by swc builds and isolated ts-jest — only `tsc --noEmit`
+        # against a real, installed, freshly generated project surfaces them.
+        run: npm run check:template-typecheck

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:mfe-drift": "ts-node scripts/check-mfe-drift.ts",
     "check:mfe-drift:check": "ts-node scripts/check-mfe-drift.ts --check",
     "check:mfe-consistency": "ts-node scripts/check-mfe-consistency.ts",
+    "check:template-typecheck": "ts-node scripts/check-template-typecheck.ts",
     "check:adr": "ts-node scripts/check-adr-consistency.ts",
     "build:adr-index": "ts-node scripts/generate-adr-index.ts",
     "build:adr-index:check": "ts-node scripts/generate-adr-index.ts --check",

--- a/packages/codegen/src/unified-generator.ts
+++ b/packages/codegen/src/unified-generator.ts
@@ -163,7 +163,14 @@ export const DEPENDENCY_VERSIONS = {
     platformBrowser: '^19.2.16',
     forms: '^19.2.16',
     rxjs: '^7.8.0',
-    zoneJs: '~0.14.0',
+    // ADR-051 recorded this as "~0.14.0 — unchanged, compatible with Angular
+    // 19", but @angular/core@19.2.16's own peerDependencies require
+    // zone.js@~0.15.0 (verified via `npm view @angular/core@19.2.16
+    // peerDependencies`) — the claim was wrong from the start, and every
+    // fresh Angular MFE install failed with ERESOLVE until this was caught by
+    // the #281 fresh-scaffold typecheck gate, which actually runs `npm
+    // install`. See `scripts/check-template-typecheck.ts`.
+    zoneJs: '~0.15.0',
   },
 
   // Angular CLI builder toolchain (angular-webpack variant).

--- a/packages/dsl/src/parser.ts
+++ b/packages/dsl/src/parser.ts
@@ -306,7 +306,7 @@ export function createMinimalManifest(
             '@angular/common': '^19.2.16',
             '@angular/platform-browser': '^19.2.16',
             'rxjs': '^7.8.0',
-            'zone.js': '~0.14.0'
+            'zone.js': '~0.15.0'
           }
         }
       : {

--- a/packages/runtime/src/angular-remote-mfe.ts
+++ b/packages/runtime/src/angular-remote-mfe.ts
@@ -73,7 +73,10 @@ export class AngularRemoteMFE extends BaseRemoteMFE {
         requiredVersion: '^19.2.16',
       },
       rxjs: { singleton: true, requiredVersion: '^7.8.0' },
-      'zone.js': { singleton: true, eager: true, requiredVersion: '~0.14.0' },
+      // @angular/core@19.2.16's peer dependency is zone.js@~0.15.0, not
+      // ~0.14.0 — see the DEPENDENCY_VERSIONS.angular.zoneJs note in
+      // unified-generator.ts (#281).
+      'zone.js': { singleton: true, eager: true, requiredVersion: '~0.15.0' },
     };
   }
 

--- a/scripts/check-template-typecheck.ts
+++ b/scripts/check-template-typecheck.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env ts-node
+/**
+ * Fresh-scaffold typecheck gate for the base-mfe template lanes (#281).
+ *
+ * The React (`base-mfe/`) and Angular (`base-mfe-angular/`) template trees
+ * encode the same BaseMFE lifecycle contract twice and are edited
+ * independently, so they drift in both directions (DX-REPORT "Meta-finding:
+ * the React and Angular templates drift"). The regressions that motivated this
+ * gate — Angular's `tsconfig.app.json.ejs` shipping a `"//"` comment key, and
+ * React's `bootstrap.ts.ejs` passing a partial `Context` — were both masked by
+ * swc builds and isolated ts-jest; only `tsc --noEmit` against a *real*,
+ * `npm install`-ed, freshly generated project surfaces them. The in-memory
+ * cross-framework contract test (`cross-framework-contract.test.ts`) is the
+ * generic guard for the string-level lifecycle surface; this script is the
+ * generic guard for the compile-level surface those assertions can't see.
+ *
+ * For each framework this: generates a scratch MFE from a minimal manifest
+ * (mirroring `remote:init` + `remote:generate`), installs its real
+ * dependencies, then runs the same `mfe:validate --typecheck` a developer
+ * would run by hand — so a fix to one path fixes both.
+ *
+ * Usage:
+ *   npx ts-node scripts/check-template-typecheck.ts            # react + angular
+ *   npx ts-node scripts/check-template-typecheck.ts --keep      # keep scratch dirs
+ *   npx ts-node scripts/check-template-typecheck.ts react       # one lane only
+ */
+
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+import { generateAllFiles, writeGeneratedFiles } from '@seans-mfe/codegen';
+import { writeManifest, generateEndpoints } from '@seans-mfe/dsl';
+import type { DSLManifest } from '@seans-mfe/dsl';
+import { mfeValidateCommand } from '../src/commands/mfe/validate';
+
+interface Lane {
+  framework: string;
+  bundler: string;
+  port: number;
+}
+
+const LANES: Lane[] = [
+  { framework: 'react', bundler: 'rspack', port: 4101 },
+  { framework: 'angular', bundler: 'webpack', port: 4102 },
+];
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DIST_RUNTIME = path.join(REPO_ROOT, 'dist', 'runtime');
+
+const KEEP = process.argv.includes('--keep');
+const requested = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const lanes = requested.length > 0 ? LANES.filter((l) => requested.includes(l.framework)) : LANES;
+
+function scratchManifest(lane: Lane): DSLManifest {
+  // Mirrors exactly what `remote:init` writes (name, port -> endpoint +
+  // remoteEntry via generateEndpoints) so the probe is realistic. Deliberately
+  // no `data:` section — BFF gating is already the cross-framework contract
+  // test's job (#271); this gate is scoped to the shared lifecycle surface,
+  // where both original regressions (DX punch items 8 and 17) actually lived.
+  return {
+    name: 'template-typecheck-probe',
+    version: '1.0.0',
+    type: 'remote',
+    language: 'typescript',
+    framework: lane.framework,
+    bundler: lane.bundler,
+    description: `Scratch probe manifest (${lane.framework}) — #281 typecheck gate`,
+    capabilities: [{ DataAnalysis: { type: 'domain', description: 'Analyze data' } }],
+    ...generateEndpoints('template-typecheck-probe', lane.port),
+  } as DSLManifest;
+}
+
+async function checkLane(lane: Lane): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), `template-typecheck-${lane.framework}-`));
+  console.log(`\n=== ${lane.framework} ===`);
+  console.log(`scratch dir: ${dir}`);
+  try {
+    const manifest = scratchManifest(lane);
+    // `mfe:validate` (invoked below) reads mfe-manifest.yaml off disk like a
+    // real MFE directory — remote:init's job, not generateAllFiles's.
+    await writeManifest(manifest, path.join(dir, 'mfe-manifest.yaml'));
+    const { files } = await generateAllFiles(manifest, dir, { force: true });
+    await writeGeneratedFiles(files, { force: true });
+
+    // `@seans-mfe-tool/runtime` isn't published to npm yet (ADR-064) — real
+    // Dockerfiles stage it via `npm pkg set ... file:.../dist/runtime`
+    // (`scripts/copy-runtime-files.js`). Mirror that here so a plain
+    // `npm install` in the scratch dir resolves the same way a real build does.
+    const pkgJsonPath = path.join(dir, 'package.json');
+    const pkgJson = await fs.readJson(pkgJsonPath);
+    if (pkgJson.devDependencies?.['@seans-mfe-tool/runtime']) {
+      pkgJson.devDependencies['@seans-mfe-tool/runtime'] = `file:${DIST_RUNTIME}`;
+    }
+    if (pkgJson.dependencies?.['@seans-mfe-tool/runtime']) {
+      pkgJson.dependencies['@seans-mfe-tool/runtime'] = `file:${DIST_RUNTIME}`;
+    }
+    await fs.writeJson(pkgJsonPath, pkgJson, { spaces: 2 });
+
+    console.log(`[${lane.framework}] npm install ...`);
+    execFileSync('npm', ['install', '--no-audit', '--no-fund'], {
+      cwd: dir,
+      stdio: 'inherit',
+    });
+
+    console.log(`[${lane.framework}] mfe:validate --typecheck ...`);
+    await mfeValidateCommand({ dir, typecheck: true });
+    console.log(`[${lane.framework}] OK`);
+  } finally {
+    if (KEEP) {
+      console.log(`kept scratch dir: ${dir}`);
+    } else {
+      await fs.remove(dir);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  if (!(await fs.pathExists(DIST_RUNTIME))) {
+    console.error(`dist/runtime not found at ${DIST_RUNTIME} — run \`npm run build\` first.`);
+    process.exit(1);
+  }
+  if (lanes.length === 0) {
+    console.error(`No matching lane(s) in: ${requested.join(', ')} (known: ${LANES.map((l) => l.framework).join(', ')})`);
+    process.exit(1);
+  }
+
+  const failures: string[] = [];
+  for (const lane of lanes) {
+    try {
+      await checkLane(lane);
+    } catch (err) {
+      failures.push(lane.framework);
+      console.error(`[${lane.framework}] FAILED: ${(err as Error).message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nTemplate typecheck gate failed for: ${failures.join(', ')}`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${lanes.length} template lane(s) typecheck cleanly from a fresh, installed scaffold.`);
+}
+
+main().catch((err) => {
+  console.error('check-template-typecheck failed:', (err as Error).message || err);
+  process.exit(1);
+});

--- a/src/commands/mfe/__tests__/validate-typecheck.test.ts
+++ b/src/commands/mfe/__tests__/validate-typecheck.test.ts
@@ -1,0 +1,109 @@
+/**
+ * mfe:validate --typecheck must check the tsconfig each framework's real build
+ * actually reads (#281).
+ *
+ * Angular's app build reads `tsconfig.app.json` (see `angular.json`'s
+ * `tsConfig`); the root `tsconfig.json` is the CommonJS config for the
+ * generated Mesh BFF, not the app build. Checking only the root config would
+ * have missed the DX punch-list #8 regression (a `"//"` comment key in
+ * `tsconfig.app.json.ejs` that broke every fresh Angular build) even with
+ * `--typecheck` on. `spawnSync` is mocked so this stays a fast, hermetic
+ * assertion on which file gets passed to `tsc -p`, not a real compile.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { spawnSync } from 'child_process';
+
+jest.mock('child_process');
+
+const mockSpawnSync = spawnSync as jest.MockedFunction<typeof spawnSync>;
+
+import { mfeValidateCommand } from '../validate';
+
+async function writeMinimalManifest(dir: string, framework: string): Promise<void> {
+  await fs.ensureDir(dir);
+  await fs.writeFile(
+    path.join(dir, 'mfe-manifest.yaml'),
+    [
+      'name: fixture-mfe',
+      'version: 1.0.0',
+      'type: remote',
+      'language: typescript',
+      `framework: ${framework}`,
+      `bundler: ${framework === 'angular' ? 'webpack' : 'rspack'}`,
+      'capabilities:',
+      '  - Demo:',
+      '      type: domain',
+      '      description: demo capability',
+    ].join('\n'),
+  );
+  await fs.writeJson(path.join(dir, 'package.json'), {
+    name: 'fixture-mfe',
+    version: '1.0.0',
+    dependencies: {},
+  });
+}
+
+describe('mfeValidateCommand --typecheck (per-framework tsconfig)', () => {
+  let tmp: string;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'mfe-validate-typecheck-'));
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    mockSpawnSync.mockReset();
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    } as ReturnType<typeof spawnSync>);
+  });
+
+  afterEach(async () => {
+    logSpy.mockRestore();
+    await fs.remove(tmp);
+  });
+
+  it('checks tsconfig.app.json for an Angular MFE, not the root tsconfig.json', async () => {
+    await writeMinimalManifest(tmp, 'angular');
+    await fs.writeFile(path.join(tmp, 'tsconfig.json'), '{"compilerOptions":{"module":"commonjs"}}');
+    await fs.writeFile(path.join(tmp, 'tsconfig.app.json'), '{"extends":"./tsconfig.json"}');
+
+    await mfeValidateCommand({ dir: tmp, typecheck: true }).catch(() => undefined);
+
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    const [, args] = mockSpawnSync.mock.calls[0];
+    expect(args).toEqual(['tsc', '--noEmit', '-p', 'tsconfig.app.json']);
+  });
+
+  it('falls back to tsconfig.json for Angular when no tsconfig.app.json exists', async () => {
+    await writeMinimalManifest(tmp, 'angular');
+    await fs.writeFile(path.join(tmp, 'tsconfig.json'), '{"compilerOptions":{}}');
+
+    await mfeValidateCommand({ dir: tmp, typecheck: true }).catch(() => undefined);
+
+    const [, args] = mockSpawnSync.mock.calls[0];
+    expect(args).toEqual(['tsc', '--noEmit', '-p', 'tsconfig.json']);
+  });
+
+  it('checks the root tsconfig.json for a React MFE', async () => {
+    await writeMinimalManifest(tmp, 'react');
+    await fs.writeFile(path.join(tmp, 'tsconfig.json'), '{"compilerOptions":{}}');
+
+    await mfeValidateCommand({ dir: tmp, typecheck: true }).catch(() => undefined);
+
+    const [, args] = mockSpawnSync.mock.calls[0];
+    expect(args).toEqual(['tsc', '--noEmit', '-p', 'tsconfig.json']);
+  });
+
+  it('does not run typecheck when no tsconfig exists', async () => {
+    await writeMinimalManifest(tmp, 'react');
+
+    const result = await mfeValidateCommand({ dir: tmp, typecheck: true }).catch((e) => e.details);
+
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(result.typecheck).toEqual({ ran: false, ok: true });
+  });
+});

--- a/src/commands/mfe/validate.ts
+++ b/src/commands/mfe/validate.ts
@@ -99,11 +99,30 @@ async function readSharedEntries(dir: string, bundler: string): Promise<ReturnTy
   return parseFederationSharedEntries(source);
 }
 
-function runTypecheck(dir: string): { ran: boolean; ok: boolean; output?: string } {
-  if (!fs.existsSync(path.join(dir, 'tsconfig.json'))) {
+/**
+ * Angular's actual app build reads `tsconfig.app.json` (see `angular.json`'s
+ * `tsConfig`), not the root `tsconfig.json` — the root config targets
+ * `commonjs` for the generated Mesh BFF (see `tsconfig.json.ejs`). Checking the
+ * root config only would have missed the DX punch-list #8 regression (a
+ * `"//"` comment key in `tsconfig.app.json.ejs` that broke every fresh
+ * Angular build) even with `--typecheck` on.
+ */
+function resolveTsconfig(dir: string, framework: string): string | undefined {
+  if (framework === 'angular' && fs.existsSync(path.join(dir, 'tsconfig.app.json'))) {
+    return 'tsconfig.app.json';
+  }
+  if (fs.existsSync(path.join(dir, 'tsconfig.json'))) {
+    return 'tsconfig.json';
+  }
+  return undefined;
+}
+
+function runTypecheck(dir: string, framework: string): { ran: boolean; ok: boolean; output?: string } {
+  const tsconfig = resolveTsconfig(dir, framework);
+  if (!tsconfig) {
     return { ran: false, ok: true };
   }
-  const res = spawnSync('npx', ['tsc', '--noEmit', '-p', 'tsconfig.json'], {
+  const res = spawnSync('npx', ['tsc', '--noEmit', '-p', tsconfig], {
     cwd: dir,
     encoding: 'utf8',
     shell: process.platform === 'win32',
@@ -143,7 +162,7 @@ export async function mfeValidateCommand(opts: MfeValidateOptions): Promise<MfeV
     sources,
   });
 
-  const typecheck = opts.typecheck ? runTypecheck(dir) : undefined;
+  const typecheck = opts.typecheck ? runTypecheck(dir, framework) : undefined;
 
   const result: MfeValidateResult = {
     mfe: (manifest as { name?: string }).name ?? path.basename(dir),


### PR DESCRIPTION
Adds the "cheap gate" option from #281: `scripts/check-template-typecheck.ts`
generates a scratch MFE per framework (mirroring remote:init + remote:generate),
runs a real `npm install`, then runs `mfe:validate --typecheck` against it.
Only a real, installed, freshly generated project surfaces the class of bug
that motivated this issue — the in-memory cross-framework contract test
(already landed for #281) checks the string-level lifecycle surface, not the
compile-level one.

Along the way, `mfe:validate --typecheck` was checking the wrong tsconfig for
Angular: the root tsconfig.json is the CommonJS config for the generated Mesh
BFF, not the app build — `ng build`/the webpack builder actually reads
tsconfig.app.json (see angular.json's tsConfig). Checking only the root config
would have missed DX punch-list #8 (the "//" comment key in
tsconfig.app.json.ejs) even with --typecheck on. Fixed in
src/commands/mfe/validate.ts to pick tsconfig.app.json for Angular when present.

Running the new gate against a real npm install also surfaced a live bug:
ADR-051 recorded zone.js as "~0.14.0 — unchanged, compatible with Angular 19",
but @angular/core@19.2.16's own peerDependencies require zone.js@~0.15.0 — the
claim was wrong from the start, so every fresh Angular MFE install failed with
ERESOLVE. Fixed the zone.js version everywhere it's declared as a fact
(unified-generator.ts's DEPENDENCY_VERSIONS, the runtime's
angular-remote-mfe.ts shared-scope negotiation, and parser.ts's
createMinimalManifest seed).

Wired as a new step in the CI quality job (.github/workflows/test.yml),
after the build step so dist/runtime exists for the runtime dependency's
file: staging.

Refs #281