### PR TITLE
ci: run the test suite on stacked pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,26 @@ name: Tests
 on:
   push:
     branches: [main, develop]
+  # The `branches:` filter on a pull_request event matches the **base**, not the
+  # head. Stacked PRs never target main — each is based on the branch below it —
+  # so `[main, develop]` silently skipped every job in this file for them. Not
+  # "pending", not "failed": zero check runs.
+  #
+  # Measured on a four-deep stack: the bottom PR had 16 check runs, the top two
+  # had none, and the only gate covering them was api-docs.yml, which has no
+  # base filter. A React import leaked into the runtime barrel and shipped
+  # through that blind spot — found by a human running `docker compose build`,
+  # not by CI.
+  #
+  # `claude/**` rather than dropping the filter: it covers the branch naming
+  # CLAUDE.md mandates without opening the suite to every fork branch.
+  #
+  # Note for whoever merges a stack: retargeting does NOT re-trigger this
+  # workflow. `pull_request` defaults to opened/synchronize/reopened, and a base
+  # change fires `edited`. After the PR below merges, push or re-run manually to
+  # get CI on the new base.
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'claude/**']
 
 jobs:
   test:


### PR DESCRIPTION
One line, and it closes a blind spot that has been silently swallowing an entire stack.

## The bug

```yaml
on:
  pull_request:
    branches: [main, develop]   # ← matches the BASE, not the head
```

Stacked PRs are the convention here — each is based on the branch below it, never on `main`. So this filter skipped **every job in this file** for them. Not pending, not failed: **zero check runs**.

Measured on the current four-deep stack:

| PR | base | check runs |
|---|---|---|
| #338 | `main` | 16 ✅ |
| #342 | `claude/adr-dangling-issues-ir9eg8` | inherited only — from when its SHA was #338's head |
| #343 | `claude/typed-errors-in-templates` | **0** |
| #344 | `claude/warn-on-platform-migrations` | **0** |

The only workflow reaching them was `api-docs.yml`, which has no base filter — and which already carries a comment explaining that a main-only trigger meant *"the drift gate could not block anything."* Same mistake, fixed there and not here.

## The cost, which was not hypothetical

A React import leaked into the runtime barrel and shipped through this blind spot, breaking three Angular MFEs at bundle time. It cleared lint, typecheck, 2600 tests, `check:mfe-drift`, `check:mfe-consistency` and `check:template-typecheck` — then failed on a human's `docker compose build`.

Two of those gates could never have caught it (`check:mfe-drift` compares bytes; `tsc` resolves types happily where webpack cannot). But the ones that might have, on the two PRs carrying the change, never ran at all.

## The change

```yaml
  pull_request:
    branches: [main, develop, 'claude/**']
```

`claude/**` rather than dropping the filter: it covers the branch naming CLAUDE.md mandates without opening the suite to every fork branch. The `push` trigger is deliberately untouched — running the full suite on every push to every working branch is waste the PR trigger already covers.

## ⚠️ For whoever merges the stack

**Retargeting does not re-trigger this workflow.** `pull_request` defaults to `opened` / `synchronize` / `reopened`; a base change fires `edited`. So after the PR below merges and GitHub retargets the next one, push an empty commit or hit "Re-run all jobs" to actually get CI on the new base. That caveat is in the workflow comment too, where it will be read at the right moment.

## Verification

- YAML parses; triggers and all six jobs (`test`, `e2e`, `perf`, `doc-links`, `adr-governance`, `quality`) resolve as expected.
- Based on `main` rather than stacked on #344 — otherwise it would inherit the very problem it fixes, which is the sort of thing that only becomes obvious afterwards.
- The real proof is this PR's own checks, plus #342/#343/#344 going from zero check runs to a full set.

Refs #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tro4E4Pd4tzX5Nm2uhc6ay

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tro4E4Pd4tzX5Nm2uhc6ay)_